### PR TITLE
Fix typo when overriding pagination components

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -42,8 +42,8 @@ export default React.createClass({
       onPageSizeChange
     } = this.props
 
-    const PreviousComponent = this.props.PreviousComponent || defaultButton
-    const NextComponent = this.props.NextComponent || defaultButton
+    const PreviousComponent = this.props.previousComponent || defaultButton
+    const NextComponent = this.props.nextComponent || defaultButton
 
     return (
       <div


### PR DESCRIPTION
Hey there, thanks a lot for this great work!

It seems there was a little typo preventing users from overriding the next/previous components. This PR fixes that. These properties are passed in lower-case to the component in `pagination.js`, but accessed in upper-case.