### PR TITLE
use `Object.getPrototypeOf` instead of `.prototype`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -193,7 +193,7 @@ function isSortingDesc (d) {
 
 function normalizeComponent (Comp, params = {}, fallback = Comp) {
   return typeof Comp === 'function' ? (
-    Comp.prototype.isReactComponent ? (
+    Object.getPrototypeOf(Comp).isReactComponent ? (
       <Comp
         {...params}
       />


### PR DESCRIPTION
This will allow the use of bound functions, which have a prototype of `undefined`. Fixes https://github.com/tannerlinsley/react-table/issues/109.