### PR TITLE
Add extra empty line to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Any values that contain bracket (`[]`) will be split.
 This array is then used as the path to the value to return.
 
 ("$" is the placeholder value that would be returned by the default accessor)
+
 | value        | path            | data                   |
 |--------------|-----------------|------------------------|
 | "a"          | ["a"]           | {"a": $}               |


### PR DESCRIPTION
causes the accessors table to show up nicely on github's page - see my fork vs main 

Thanks for this component it is really good!