### PR TITLE
Switch `-sort-asc` and `-sort-desc` in ternaries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -286,7 +286,7 @@ export default React.createClass({
                 'rt-pivot-header',
                 column.sortable && '-cursor-pointer',
                 classes,
-                pivotSort ? (pivotSort.desc ? '-sort-asc' : '-sort-desc') : ''
+                pivotSort ? (pivotSort.desc ? '-sort-desc' : '-sort-asc') : ''
               )}
               style={{
                 ...styles,
@@ -337,7 +337,7 @@ export default React.createClass({
           key={i}
           className={classnames(
             classes,
-            sort ? (sort.desc ? '-sort-asc' : '-sort-desc') : '',
+            sort ? (sort.desc ? '-sort-desc' : '-sort-asc') : '',
             column.sortable && '-cursor-pointer',
             !show && '-hidden',
           )}


### PR DESCRIPTION
Renames the sorting class names appropriately. Fixes https://github.com/tannerlinsley/react-table/issues/137