### PR TITLE
Added an id to the Friend Name column in the example so it doesn't error

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ const columns = [{
   accessor: 'age',
   render: props => <span className='number'>{props.value}</span> // Custom cell components!
 }, {
+  id: 'friendName', // Required because our accessor is not a string
   header: 'Friend Name',
   accessor: d => d.friend.name // Custom value accessors!
 }, {


### PR DESCRIPTION
When I pasted your example into my project I got the following error:

`Uncaught Error: A column id is required if using a non-string accessor for column above.`

Adding an id to the `Friend Name` column fixed the error as the accessor is not a string.

After a bit of reading through your docs I worked out what the problem was, but thought as it's a quick fix I'll create a PR as well.