### PR TITLE
Avoid page refresh if same page, set NaN to current page

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -17,12 +17,17 @@ export default React.createClass({
     this.setState({page: nextProps.page})
   },
   getSafePage (page) {
+    if(isNaN(page)) {
+        page = this.props.page
+    }
     return Math.min(Math.max(page, 0), this.props.pages - 1)
   },
   changePage (page) {
     page = this.getSafePage(page)
     this.setState({page})
-    this.props.onPageChange(page)
+    if(this.props.page!==page) {
+      this.props.onPageChange(page)
+    }
   },
   applyPage (e) {
     e && e.preventDefault()

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -17,15 +17,15 @@ export default React.createClass({
     this.setState({page: nextProps.page})
   },
   getSafePage (page) {
-    if(isNaN(page)) {
-        page = this.props.page
+    if (isNaN(page)) {
+      page = this.props.page
     }
     return Math.min(Math.max(page, 0), this.props.pages - 1)
   },
   changePage (page) {
     page = this.getSafePage(page)
     this.setState({page})
-    if(this.props.page!==page) {
+    if (this.props.page !== page) {
       this.props.onPageChange(page)
     }
   },


### PR DESCRIPTION
This fixes issue [169](https://github.com/tannerlinsley/react-table/issues/169)

* The top change asks if the new page is really a number before trying to use it (this avoids warning when typing two non-numeric characters) and return the current page otherwise

* The bottom change verifies that the current page is not the same as the new page