### PR TITLE
when you have no data pages shows as 0 instead of 1

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -104,7 +104,7 @@ export default class ReactTablePagination extends Component {
               </div>
             ) : (
               <span className='-currentPage'>{page + 1}</span>
-            )} {this.props.ofText} <span className='-totalPages'>{pages}</span>
+            )} {this.props.ofText} <span className='-totalPages'>{pages || 1}</span>
           </span>
           {showPageSizeOptions && (
             <span className='select-wrap -pageSizeOptions'>


### PR DESCRIPTION
see the No Data in the example storybook. Pagination at the bottom shows 1 of 0 instead of 1 of 1.

https://react-table.js.org/?selectedKind=2.%20Demos&selectedStory=Custom%20%22No%20Data%22%20Text&full=0&down=0&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel