### PR TITLE
Documentation example of using pivotRender

### DIFF
--- a/stories/PivotingOptions.js
+++ b/stories/PivotingOptions.js
@@ -129,6 +129,7 @@ const columns = [{
 }, {
   header: () => <strong>First &#8674; Last Name Pivot</strong>,
   expander: true,
+  pivotRender: row => <span>{row.value}</span>,
   minWidth: 200,
   render: ({isExpanded, ...rest}) => (
     isExpanded ? <span> &#10136; </span> : <span> &#10137; </span>


### PR DESCRIPTION
Thanks @aaronschwartz for pointing out correct usage of pivotRender to remove the `(count)` in the group header. Didn't seem to be documented yet, but looks like it should be possible to work into the Pivoting Options example.