### PR TITLE
Add column id to the rowInfo object

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -27,6 +27,7 @@ import Footers from '../stories/Footers.js'
 import Filtering from '../stories/Filtering.js'
 import ControlledTable from '../stories/ControlledTable.js'
 import PivotingOptions from '../stories/PivotingOptions.js'
+import EditableTable from '../stories/EditableTable.js'
 //
 configure(() => {
   storiesOf('1. Docs')
@@ -59,4 +60,5 @@ configure(() => {
     .add('Footers', Footers)
     .add('Custom Filtering', Filtering)
     .add('Controlled Component', ControlledTable)
+    .add('Editable table', EditableTable)
 }, module)

--- a/README.md
+++ b/README.md
@@ -330,10 +330,11 @@ Or just define them as props
   // Cell Options
   className: '', // Set the classname of the `td` element of the column
   style: {}, // Set the style of the `td` element of the column
-  render: JSX eg. (rowInfo: {value, rowValues, row, index, viewIndex}) => <span>{value}</span>, // Provide a JSX element or stateless function to render whatever you want as the column's cell with access to the entire row
+  render: JSX eg. (cellInfo: {value, rowValues, row, column, index, viewIndex}) => <span>{value}</span>, // Provide a JSX element or stateless function to render whatever you want as the column's cell with access to the entire row
     // value == the accessed value of the column
     // rowValues == an object of all of the accessed values for the row
     // row == the original row of data supplied to the table
+    // column == the column properties (id, header, sortable, ...)
     // index == the original index of the data supplied to the table
     // viewIndex == the index of the row in the current page
 
@@ -482,8 +483,8 @@ Every single built-in component's props can be dynamically extended using any on
   getTdProps={fn}
   getPaginationProps={fn}
   getLoadingProps={fn}
-  getNoDataProps: {fn},
-  getResizerProps: {fn}
+  getNoDataProps={fn}
+  getResizerProps={fn}
 />
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -460,7 +460,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
             {...trProps.rest}
           >
             {allVisibleColumns.map((column, i2) => {
-              const cellInfo = { ...rowInfo, column: {...column} };
+              const cellInfo = { ...rowInfo, column: {...column} }
               const resized = resizing.find(x => x.id === column.id) || {}
               const show = typeof column.show === 'function' ? column.show() : column.show
               const width = _.getFirstDefined(resized.value, column.width, column.minWidth)

--- a/src/index.js
+++ b/src/index.js
@@ -547,7 +547,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
             {...trProps.rest}
           >
             {allVisibleColumns.map((column, i2) => {
-              rowInfo['columnId'] = column.id
+              const cellInfo = { ...rowInfo, column: {...column} };
               const resized = resizing.find(x => x.id === column.id) || {}
               const show = typeof column.show === 'function' ? column.show() : column.show
               const width = _.getFirstDefined(resized.value, column.width, column.minWidth)
@@ -572,16 +572,16 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
               if (column.expander) {
                 const onTdClick = (e) => {
                   if (onExpandRow) {
-                    return onExpandRow(rowInfo.nestingPath, e)
+                    return onExpandRow(cellInfo.nestingPath, e)
                   }
                   let newExpandedRows = _.clone(expandedRows)
                   if (isExpanded) {
                     return this.setStateWithData({
-                      expandedRows: _.set(newExpandedRows, rowInfo.nestingPath, false)
+                      expandedRows: _.set(newExpandedRows, cellInfo.nestingPath, false)
                     })
                   }
                   return this.setStateWithData({
-                    expandedRows: _.set(newExpandedRows, rowInfo.nestingPath, {})
+                    expandedRows: _.set(newExpandedRows, cellInfo.nestingPath, {})
                   })
                 }
 
@@ -599,7 +599,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                       )}
                       style={{
                         ...styles,
-                        paddingLeft: rowInfo.nestingPath.length === 1 ? undefined : `${30 * (rowInfo.nestingPath.length - 1)}px`,
+                        paddingLeft: cellInfo.nestingPath.length === 1 ? undefined : `${30 * (cellInfo.nestingPath.length - 1)}px`,
                         flex: `${width} 0 auto`,
                         width: `${width}px`,
                         maxWidth: `${maxWidth}px`
@@ -607,27 +607,27 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                       {...tdProps.rest}
                       onClick={onTdClick}
                     >
-                      {rowInfo.subRows ? (
+                      {cellInfo.subRows ? (
                         <span>
                           {_.normalizeComponent(column.render, {
-                            ...rowInfo,
-                            value: rowInfo.rowValues[column.id],
+                            ...cellInfo,
+                            value: cellInfo.rowValues[column.id],
                             isExpanded
-                          }, rowInfo.rowValues[column.id])}
+                          }, cellInfo.rowValues[column.id])}
                           {column && column.pivotRender ? (
                             <PivotCell
-                              {...rowInfo}
-                              value={rowInfo.rowValues[pivotValKey]}
+                              {...cellInfo}
+                              value={cellInfo.rowValues[pivotValKey]}
                             />
-                          ) : <span>{row[pivotValKey]} ({rowInfo.subRows.length})</span>}
+                          ) : <span>{row[pivotValKey]} ({cellInfo.subRows.length})</span>}
                         </span>
                       ) : SubComponent ? (
                         <span>
                           {_.normalizeComponent(column.render, {
-                            ...rowInfo,
-                            value: rowInfo.rowValues[column.id],
+                            ...cellInfo,
+                            value: cellInfo.rowValues[column.id],
                             isExpanded
-                          }, rowInfo.rowValues[column.id])}
+                          }, cellInfo.rowValues[column.id])}
                         </span>
                       ) : null}
                     </TdComponent>
@@ -653,10 +653,10 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                   {...extraProps}
                 >
                   {_.normalizeComponent(column.render, {
-                    ...rowInfo,
-                    value: rowInfo.rowValues[column.id],
+                    ...cellInfo,
+                    value: cellInfo.rowValues[column.id],
                     isExpanded
-                  }, rowInfo.rowValues[column.id])}
+                  }, cellInfo.rowValues[column.id])}
                 </TdComponent>
               )
             })}

--- a/src/index.js
+++ b/src/index.js
@@ -547,6 +547,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
             {...trProps.rest}
           >
             {allVisibleColumns.map((column, i2) => {
+              rowInfo['columnId'] = column.id
               const resized = resizing.find(x => x.id === column.id) || {}
               const show = typeof column.show === 'function' ? column.show() : column.show
               const width = _.getFirstDefined(resized.value, column.width, column.minWidth)

--- a/stories/EditableTable.js
+++ b/stories/EditableTable.js
@@ -1,0 +1,124 @@
+import React from 'react'
+import _ from 'lodash'
+import namor from 'namor'
+
+import CodeHighlight from './components/codeHighlight'
+import ReactTable from '../src/index'
+
+class MyTable extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.renderEditable = this.renderEditable.bind(this);
+
+    this.state = {
+      data: [
+        { firstName: 'Lucy', lastName: 'Marks' },
+        { firstName: 'Bejamin', lastName: 'Pike' }
+      ]
+    };
+
+    this.columns = [
+      {
+        header: 'First Name',
+        accessor: 'firstName',
+        render: this.renderEditable
+      },
+      {
+        header: 'Last Name',
+        accessor: 'lastName',
+        render: this.renderEditable
+      },
+      {
+        header: 'Full Name',
+        id: 'full',
+        accessor: d => d.firstName + ' ' + d.lastName
+      }
+    ];
+  }
+
+  renderEditable(rowInfo) {
+    return (<div style={{ backgroundColor: '#fafafa' }} contentEditable onBlur={(e) => {
+      console.log('edit', e.target.textContent);
+      const data = [...this.state.data];
+      data[rowInfo.index][rowInfo.columnId] = e.target.textContent;
+      this.setState({data: data});
+    }}>{this.state.data[rowInfo.index][rowInfo.columnId]}</div>);
+  }
+
+  render() {
+    return (<ReactTable
+      data={this.state.data}
+      columns={this.columns}
+      defaultPageSize={2}
+      showPageSizeOptions={false}
+      showPagination={false}
+    />);
+  }
+}
+
+function getCode() {
+  return `
+class MyTable extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.renderEditable = this.renderEditable.bind(this);
+
+    this.state = {
+      data: [
+        { firstName: 'Lucy', lastName: 'Marks' },
+        { firstName: 'Bejamin', lastName: 'Pike' }
+      ]
+    };
+
+    this.columns = [
+      {
+        header: 'First Name',
+        accessor: 'firstName',
+        render: this.renderEditable
+      },
+      {
+        header: 'Last Name',
+        accessor: 'lastName',
+        render: this.renderEditable
+      },
+      {
+        header: 'Full Name',
+        id: 'full',
+        accessor: d => d.firstName + ' ' + d.lastName
+      }
+    ];
+  }
+
+  renderEditable(rowInfo) {
+    return (<div style={{ backgroundColor: '#fafafa' }} contentEditable onBlur={(e) => {
+      console.log('edit', e.target.textContent);
+      const data = [...this.state.data];
+      data[rowInfo.index][rowInfo.columnId] = e.target.textContent;
+      this.setState({data: data});
+    }}>{this.state.data[rowInfo.index][rowInfo.columnId]}</div>);
+  }
+
+  render() {
+    return (<ReactTable
+      data={this.state.data}
+      columns={this.columns}
+      defaultPageSize={10}
+    />);
+  }
+}
+`
+}
+
+export default () => {
+
+  return (
+    <div>
+      <p>First two columns are editable just by clicking into them using the <code>contentEditable</code> attribute. Last column (Full Name) is computed from the first two.</p>
+      <div className='table-wrap' style={{marginBottom: '20px'}}>
+        <MyTable />
+      </div>
+
+      <CodeHighlight>{() => getCode()}</CodeHighlight>
+    </div>
+  )
+}

--- a/stories/EditableTable.js
+++ b/stories/EditableTable.js
@@ -36,13 +36,12 @@ class MyTable extends React.Component {
     ];
   }
 
-  renderEditable(rowInfo) {
-    return (<div style={{ backgroundColor: '#fafafa' }} contentEditable onBlur={(e) => {
-      console.log('edit', e.target.textContent);
+  renderEditable(cellInfo) {
+    return (<div style={{ backgroundColor: '#fafafa' }} contentEditable suppressContentEditableWarning onBlur={(e) => {
       const data = [...this.state.data];
-      data[rowInfo.index][rowInfo.columnId] = e.target.textContent;
+      data[cellInfo.index][cellInfo.column.id] = e.target.textContent;
       this.setState({data: data});
-    }}>{this.state.data[rowInfo.index][rowInfo.columnId]}</div>);
+    }}>{this.state.data[cellInfo.index][cellInfo.column.id]}</div>);
   }
 
   render() {
@@ -89,20 +88,21 @@ class MyTable extends React.Component {
     ];
   }
 
-  renderEditable(rowInfo) {
-    return (<div style={{ backgroundColor: '#fafafa' }} contentEditable onBlur={(e) => {
-      console.log('edit', e.target.textContent);
+  renderEditable(cellInfo) {
+    return (<div style={{ backgroundColor: '#fafafa' }} contentEditable suppressContentEditableWarning onBlur={(e) => {
       const data = [...this.state.data];
-      data[rowInfo.index][rowInfo.columnId] = e.target.textContent;
+      data[cellInfo.index][cellInfo.column.id] = e.target.textContent;
       this.setState({data: data});
-    }}>{this.state.data[rowInfo.index][rowInfo.columnId]}</div>);
+    }}>{this.state.data[cellInfo.index][cellInfo.column.id]}</div>);
   }
 
   render() {
     return (<ReactTable
       data={this.state.data}
       columns={this.columns}
-      defaultPageSize={10}
+      defaultPageSize={2}
+      showPageSizeOptions={false}
+      showPagination={false}
     />);
   }
 }


### PR DESCRIPTION
Would you consider adding `columnId` property to the `rowInfo` object? It would be very useful when referencing data in a table in a generic way. I've explained the rationale in the #237 as well.