### PR TITLE
Fixed issue #210 - Ignore filters on hidden columns.

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -323,17 +323,7 @@ export default Base => class extends Base {
             (row) => {
               let column
 
-              column = allVisibleColumns.find(x => x.id === nextFilter.id || (x.pivotColumns && x.pivotColumns.some(y => y.id === nextFilter.id)))
-
-              // Don't filter hidden columns
-              if (!column) {
-                return true
-              }
-
-              // Could possibly be in pivotColumns
-              if (column.id !== nextFilter.id && column.pivotColumns) {
-                column = column.pivotColumns.find(x => x.id === nextFilter.id)
-              }
+              column = allVisibleColumns.find(x => x.id === nextFilter.id)
 
               // Don't filter hidden columns or columns that have had their filters disabled
               if (!column || column.filterable === false) {

--- a/src/methods.js
+++ b/src/methods.js
@@ -325,6 +325,11 @@ export default Base => class extends Base {
 
               column = allVisibleColumns.find(x => x.id === nextFilter.id || (x.pivotColumns && x.pivotColumns.some(y => y.id === nextFilter.id)))
 
+              // Don't filter hidden columns
+              if (!column) {
+                return true
+              }
+
               // Could possibly be in pivotColumns
               if (column.id !== nextFilter.id && column.pivotColumns) {
                 column = column.pivotColumns.find(x => x.id === nextFilter.id)


### PR DESCRIPTION
I just added a little change. As a column may be hidden, we must check it is not `undefined` before trying to access the `id` prop. This check was made in commit 6401786, but some changes made it appear a few lines after accessing the `id` prop in v6.0.0.