### PR TITLE
Add an option to hide the pagination if there is no data

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ These are all of the available props (and their default values) for the main `<R
   data: [],
   loading: false,
   showPagination: true,
+  showPaginationNoData: true,
   showPageSizeOptions: true,
   pageSizeOptions: [5, 10, 20, 25, 50, 100],
   defaultPageSize: 20,

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -20,6 +20,7 @@ import OneHundredKRows from './stories/OneHundredKRows.js'
 import FunctionalRendering from './stories/FunctionalRendering.js'
 import CustomExpanderPosition from './stories/CustomExpanderPosition.js'
 import NoDataText from './stories/NoDataText.js'
+import ShowPaginationNoData from './stories/ShowPaginationNoData.js'
 import Footers from './stories/Footers.js'
 import Filtering from './stories/Filtering.js'
 import ControlledTable from './stories/ControlledTable.js'
@@ -96,6 +97,7 @@ export default class App extends React.Component {
             component: CustomExpanderPosition
           },
           { name: 'Custom "No Data" Text', component: NoDataText },
+          { name: 'Show Pagination No Data', component: ShowPaginationNoData },
           { name: 'Footers', component: Footers },
           { name: 'Custom Filtering', component: Filtering },
           { name: 'Controlled Component', component: ControlledTable },

--- a/docs/src/stories/ShowPaginationNoData.js
+++ b/docs/src/stories/ShowPaginationNoData.js
@@ -1,0 +1,57 @@
+/* eslint-disable import/no-webpack-loader-syntax */
+import React from 'react'
+
+import ReactTable from '../../../lib/index'
+
+class Story extends React.PureComponent {
+  render () {
+    const columns = [{
+      Header: 'Name',
+      columns: [{
+        Header: 'First Name',
+        accessor: 'firstName'
+      }, {
+        Header: 'Last Name',
+        id: 'lastName',
+        accessor: d => d.lastName
+      }]
+    }, {
+      Header: 'Info',
+      columns: [{
+        Header: 'Age',
+        accessor: 'age'
+      }]
+    }]
+
+    return (
+      <div>
+        <div className='table-wrap'>
+          <ReactTable
+            className='-striped -highlight'
+            data={[]}
+            noDataText='No rows found'
+            showPagination={true}
+            showPaginationNoData={false}
+            columns={columns}
+            defaultPageSize={10}
+          />
+        </div>
+        <div style={{textAlign: 'center'}}>
+          <br />
+          <em>Tip: Hold shift when sorting to multi-sort!</em>
+        </div>
+      </div>
+    )
+  }
+}
+
+// Source Code
+const CodeHighlight = require('./components/codeHighlight').default
+const source = require('!raw!./ShowPaginationNoData')
+
+export default () => (
+  <div>
+    <Story />
+    <CodeHighlight>{() => source}</CodeHighlight>
+  </div>
+)

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -11,6 +11,7 @@ export default {
   data: [],
   loading: false,
   showPagination: true,
+  showPaginationNoData: true,
   showPageSizeOptions: true,
   pageSizeOptions: [5, 10, 20, 25, 50, 100],
   defaultPageSize: 20,

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
       getNoDataProps,
       getResizerProps,
       showPagination,
+      showPaginationNoData,
       manual,
       loadingText,
       noDataText,
@@ -766,6 +767,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
     const noDataProps = getNoDataProps(finalState, undefined, undefined, this)
     const resizerProps = getResizerProps(finalState, undefined, undefined, this)
 
+    const hasData = pageRows.length
+
     const makeTable = () => (
       <div
         className={classnames(
@@ -803,7 +806,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
           </TbodyComponent>
           {hasColumnFooter ? makeColumnFooters() : null}
         </TableComponent>
-        {showPagination ? (
+        {showPagination && (showPaginationNoData || hasData) ? (
           <PaginationComponent
             {...resolvedState}
             pages={pages}
@@ -816,7 +819,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
             {...paginationProps.rest}
           />
         ) : null}
-        {!pageRows.length && (
+        {!hasData && (
           <NoDataComponent
             {...noDataProps}
           >


### PR DESCRIPTION
This will take priority over the default showPagination prop. It is set to a default of 'true'.

It is demonstrated in a 'ShowPaginationNoData' story.

Relates to #130, #248. The latter had some valid reasons on why this behavior should not be the default, so I added it as an option. 