### PR TITLE
fix IE select visual bug

### DIFF
--- a/src/index.styl
+++ b/src/index.styl
@@ -305,6 +305,8 @@ $expandSize = 7px
   input:not([type="checkbox"]):not([type="radio"])
   select
     appearance: none
+    &::-ms-expand
+      display: none
 
   .select-wrap
     position:relative


### PR DESCRIPTION
This fix is for a IE bug regarding the select element. On IE, the default browser arrow was still being shown due to a appearance property bug.

![image](https://cloud.githubusercontent.com/assets/25583696/26548639/da2294aa-447d-11e7-830b-4689d26f4788.png)
