### PR TITLE
Max width NaN fix

### DIFF
--- a/docs/src/stories/ControlledTable.js
+++ b/docs/src/stories/ControlledTable.js
@@ -21,7 +21,8 @@ const columns = [{
   }, {
     Header: 'Last Name',
     id: 'lastName',
-    accessor: d => d.lastName
+    accessor: d => d.lastName,
+    width: 170
   }]
 }, {
   Header: 'Info',
@@ -31,21 +32,31 @@ const columns = [{
   }]
 }]
 
+function makeDefaultState()
+{
+  return {
+    sorted: [],
+    page: 0,
+    pageSize: 10,
+    expanded: {},
+    resized: [],
+    filtered: []
+  }
+}
+
 class Story extends React.PureComponent {
   constructor () {
     super()
-    this.state = {
-      sorted: [],
-      page: 0,
-      pageSize: 10,
-      expanded: {},
-      resized: [],
-      filtered: []
-    }
+    this.state = makeDefaultState()
+    this.resetState = this.resetState.bind(this)
+  }
+  resetState(){
+    this.setState(makeDefaultState())
   }
   render () {
     return (
       <div>
+
         <div className='table-wrap'>
           <ReactTable
             className='-striped -highlight'
@@ -70,6 +81,7 @@ class Story extends React.PureComponent {
           />
         </div>
         <br />
+        <div style={{float:'right'}}><button onClick={this.resetState}>Reset State</button></div>
         <pre><code><strong>this.state ===</strong> {JSON.stringify(this.state, null, 2)}</code></pre>
         <br />
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -261,8 +261,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
 
       const flexStyles = {
         flex: `${flex} 0 auto`,
-        width: `${width}px`,
-        maxWidth: `${maxWidth}px`,
+        width: _.asPx(width),
+        maxWidth: _.asPx(maxWidth),
       }
 
       return (
@@ -376,8 +376,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
           style={{
             ...styles,
             flex: `${width} 0 auto`,
-            width: `${width}px`,
-            maxWidth: `${maxWidth}px`,
+            width: _.asPx(width),
+            maxWidth: _.asPx(maxWidth),
           }}
           toggleSort={e => {
             isSortable && this.sortColumn(column, e.shiftKey)
@@ -475,8 +475,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
           style={{
             ...styles,
             flex: `${width} 0 auto`,
-            width: `${width}px`,
-            maxWidth: `${maxWidth}px`,
+            width: _.asPx(width),
+            maxWidth: _.asPx(maxWidth),
           }}
           {...rest}
         >
@@ -706,8 +706,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                   style={{
                     ...styles,
                     flex: `${width} 0 auto`,
-                    width: `${width}px`,
-                    maxWidth: `${maxWidth}px`,
+                    width: _.asPx(width),
+                    maxWidth: _.asPx(maxWidth),
                   }}
                   {...interactionProps}
                   {...tdProps.rest}
@@ -798,8 +798,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
           style={{
             ...styles,
             flex: `${flex} 0 auto`,
-            width: `${width}px`,
-            maxWidth: `${maxWidth}px`,
+            width: _.asPx(width),
+            maxWidth: _.asPx(maxWidth),
           }}
           {...tdProps.rest}
         >
@@ -878,8 +878,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
           style={{
             ...styles,
             flex: `${width} 0 auto`,
-            width: `${width}px`,
-            maxWidth: `${maxWidth}px`,
+            width: _.asPx(width),
+            maxWidth: _.asPx(maxWidth),
           }}
           {...columnProps.rest}
           {...tFootTdProps.rest}

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@ export default {
   compactObject,
   isSortingDesc,
   normalizeComponent,
-  asPx
+  asPx,
 }
 
 function get (obj, path, def) {
@@ -143,11 +143,10 @@ function groupBy (xs, key) {
   }, {})
 }
 
-function asPx(value) {
-  value = Number(value);
+function asPx (value) {
+  value = Number(value)
   return (Number.isNaN(value)) ? null : value + 'px'
 }
-
 
 function isArray (a) {
   return Array.isArray(a)

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,7 @@ export default {
   compactObject,
   isSortingDesc,
   normalizeComponent,
+  asPx
 }
 
 function get (obj, path, def) {
@@ -141,6 +142,12 @@ function groupBy (xs, key) {
     return rv
   }, {})
 }
+
+function asPx(value) {
+  value = Number(value);
+  return (Number.isNaN(value)) ? null : value + 'px'
+}
+
 
 function isArray (a) {
   return Array.isArray(a)


### PR DESCRIPTION
This PR is related to issues described in #387

When a cell's maxWidth is NaN, the calculated style.maxWidth is `"NaNpx"`. React won't update the DOM's style when given this value, resulting in incorrectly sized columns.

This PR ensures the maxWidth style is properly handled when maxWidth is NaN.

Note this PR also will add a button to the Controlled Component story to allow the user to reset the controlled state.