### PR TITLE
TravisCI: Use node version 10 (fixes TravisCI builds)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "6"
+  - "10"
 script: npm test


### PR DESCRIPTION
We should use node version 10 since it's the active LTS until 2021-04-01. See [Node.js Releases](https://nodejs.org/en/about/releases/) for more info.

This should also fix the TravisCI builds.