### PR TITLE
TravisCI: Cache yarn files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
   - "10"
+
+cache: yarn
+
 script: npm test


### PR DESCRIPTION
Cache yarn files like it is recommended by [TravisCI docs](https://docs.travis-ci.com/user/caching/#yarn-cache) for a faster build time.