### PR TITLE
Fixes/pass cell info to onExpandedChange handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -533,7 +533,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                   {
                     expanded: newExpanded,
                   },
-                  () => onExpandedChange && onExpandedChange(newExpanded, cellInfo.nestingPath, e)
+                  () => onExpandedChange && onExpandedChange(newExpanded, cellInfo.nestingPath, e, cellInfo)
                 )
               }
 


### PR DESCRIPTION
Pass complete row information to onExpandedChange handler.

In response to this:
https://github.com/tannerlinsley/react-table/issues/1201