### PR TITLE
Remove usage JSON.stringify where possible

### DIFF
--- a/docs/src/stories/HOCReadme.js
+++ b/docs/src/stories/HOCReadme.js
@@ -2,7 +2,7 @@
 import React from "react";
 import marked from "marked";
 //
-import HOCReadme from "!raw!../../../src/hoc/README.md";
+// import HOCReadme from "!raw!../../../src/hoc/README.md";
 import "github-markdown-css/github-markdown.css";
 import "./utils/prism.js";
 
@@ -12,7 +12,7 @@ export default class HOCStory extends React.Component {
       <div style={{ padding: "10px" }}>
         <span
           className="markdown-body"
-          dangerouslySetInnerHTML={{ __html: marked(HOCReadme) }}
+          dangerouslySetInnerHTML={{ __html: marked("HOCReadme") }}
         />
       </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-table",
-  "version": "6.8.7",
+  "version": "6.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3234,7 +3234,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3248,8 +3249,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -3264,7 +3265,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3331,7 +3332,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -3346,14 +3347,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -3362,12 +3363,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -3382,7 +3383,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -3391,7 +3392,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -3400,8 +3401,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3422,7 +3423,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -3437,7 +3438,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -3452,8 +3453,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -3462,7 +3463,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -3486,9 +3487,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -3497,16 +3498,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -3515,8 +3516,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -3531,8 +3532,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -3541,10 +3542,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -3565,7 +3566,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -3586,8 +3587,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -3608,10 +3609,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3628,13 +3629,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -3643,13 +3644,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3687,9 +3689,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -3698,15 +3700,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -3721,13 +3724,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -3742,18 +3745,20 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -257,8 +257,22 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
     }
 
     const makeHeaderGroups = () => {
-      const theadGroupProps = _.splitProps(getTheadGroupProps(finalState, undefined, undefined, this))
-      const theadGroupTrProps = _.splitProps(getTheadGroupTrProps(finalState, undefined, undefined, this))
+      const theadGroupProps = _.splitProps(
+        getTheadGroupProps(
+          finalState,
+          undefined,
+          undefined,
+          this
+        )
+      )
+      const theadGroupTrProps = _.splitProps(
+        getTheadGroupTrProps(
+          finalState,
+          undefined,
+          undefined,
+          this
+        )
+      )
       return (
         <TheadComponent
           className={classnames('-headerGroups', theadGroupProps.className)}

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -17,7 +17,7 @@ export default Base =>
       const defaultableOptions = ['sorted', 'filtered', 'resized', 'expanded']
       defaultableOptions.forEach(x => {
         const defaultName = `default${x.charAt(0).toUpperCase() + x.slice(1)}`
-        if (JSON.stringify(oldState[defaultName]) !== JSON.stringify(newState[defaultName])) {
+        if (compare(oldState[defaultName], newState[defaultName])) {
           newState[x] = newState[defaultName]
         }
       })

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,3 +1,5 @@
+import compare from './utils'
+
 export default Base =>
   class extends Base {
     componentWillMount () {

--- a/src/methods.js
+++ b/src/methods.js
@@ -625,8 +625,15 @@ export default Base =>
       event.stopPropagation()
       const { onResizedChange, column } = this.props
       const { resized, currentlyResizing, columns } = this.getResolvedState()
-      const currentColumn = columns.find(c => c.accessor === currentlyResizing.id || c.id === currentlyResizing.id)
-      const minResizeWidth = currentColumn && currentColumn.minResizeWidth != null ? currentColumn.minResizeWidth : column.minResizeWidth
+      const currentColumn =
+        columns.find(c =>
+          c.accessor === currentlyResizing.id
+          || c.id === currentlyResizing.id
+        )
+      const minResizeWidth =
+        currentColumn && currentColumn.minResizeWidth != null
+          ? currentColumn.minResizeWidth
+          : column.minResizeWidth
 
       // Delete old value
       const newResized = resized.filter(x => x.id !== currentlyResizing.id)

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,7 @@ export default {
   range,
   remove,
   clone,
+  compare,
   getFirstDefined,
   sum,
   makeTemplateComponent,
@@ -93,20 +94,20 @@ function remove (a, b) {
   })
 }
 
-function clone (a) {
-  try {
-    return JSON.parse(
-      JSON.stringify(a, (key, value) => {
-        if (typeof value === 'function') {
-          return value.toString()
-        }
-        return value
-      })
-    )
-  } catch (e) {
-    return a
-  }
-}
+// function clone (a) {
+//   try {
+//     return JSON.parse(
+//       JSON.stringify(a, (key, value) => {
+//         if (typeof value === 'function') {
+//           return value.toString()
+//         }
+//         return value
+//       })
+//     )
+//   } catch (e) {
+//     return a
+//   }
+// }
 
 function getFirstDefined (...args) {
   for (let i = 0; i < args.length; i += 1) {
@@ -209,4 +210,108 @@ function normalizeComponent (Comp, params = {}, fallback = Comp) {
   ) : (
     fallback
   )
+}
+
+function clone (obj) {
+  if (typeof obj === 'function') {
+    return JSON.parse(JSON.stringify(obj.toString()))
+  }
+  const result = Array.isArray(obj) ? [] : {}
+  /* eslint-disable guard-for-in */
+  /* eslint-disable no-restricted-syntax */
+  for (const key in obj) {
+    // include prototype properties
+    const value = obj[key]
+    const type = {}.toString.call(value).slice(8, -1)
+    if (type === 'Array' || type === 'Object') {
+      result[key] = clone(value)
+    } else if (type === 'Date') {
+      result[key] = new Date(value.getTime())
+    } else if (type === 'RegExp') {
+      result[key] = RegExp(value.source, getRegExpFlags(value))
+    } else {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+/* eslint-disable no-unused-expressions */
+function getRegExpFlags (regExp) {
+  if (typeof regExp.source.flags === 'string') {
+    return regExp.source.flags
+  }
+  const flags = []
+  regExp.global && flags.push('g')
+  regExp.ignoreCase && flags.push('i')
+  regExp.multiline && flags.push('m')
+  regExp.sticky && flags.push('y')
+  regExp.unicode && flags.push('u')
+  return flags.join('')
+}
+
+function compare(value1, value2) {
+  if (value1 === value2) {
+    return true;
+  }
+  /* eslint-disable no-self-compare */
+  // if both values are NaNs return true
+  if ((value1 !== value1) && (value2 !== value2)) {
+    return true;
+  }
+  if ({}.toString.call(value1) != {}.toString.call(value2)) {
+    return false;
+  }
+  if (value1 !== Object(value1)) {
+    // non equal primitives
+    return false;
+  }
+  if (!value1) {
+    return false;
+  }
+  if (Array.isArray(value1)) {
+    return compareArrays(value1, value2);
+  }
+  if ({}.toString.call(value1) == '[object Object]') {
+    return compareObjects(value1, value2);
+  } else {
+    return compareNativeSubtypes(value1, value2);
+  }
+}
+
+function compareNativeSubtypes(value1, value2) {
+  // e.g. Function, RegExp, Date
+  return value1.toString() === value2.toString();
+}
+
+function compareArrays(value1, value2) {
+  var len = value1.length;
+  if (len != value2.length) {
+    return false;
+  }
+  var alike = true;
+  for (var i = 0; i < len; i++) {
+    if (!compare(value1[i], value2[i])) {
+      alike = false;
+      break;
+    }
+  }
+  return alike;
+}
+
+function compareObjects(value1, value2) {
+  var keys1 = Object.keys(value1).sort();
+  var keys2 = Object.keys(value2).sort();
+  var len = keys1.length;
+  if (len != keys2.length) {
+    return false;
+  }
+  for (var i = 0; i < len; i++) {
+    var key1 = keys1[i];
+    var key2 = keys2[i];
+    if (!(key1 == key2 && compare(value1[key1], value2[key2]))) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -250,68 +250,72 @@ function getRegExpFlags (regExp) {
   return flags.join('')
 }
 
-function compare(value1, value2) {
+function compare (value1, value2) {
   if (value1 === value2) {
-    return true;
+    return true
   }
-  /* eslint-disable no-self-compare */
+
   // if both values are NaNs return true
+  /* eslint-disable no-self-compare */
   if ((value1 !== value1) && (value2 !== value2)) {
-    return true;
+    return true
   }
+  /* eslint-disable eqeqeq */
   if ({}.toString.call(value1) != {}.toString.call(value2)) {
-    return false;
+    return false
   }
   if (value1 !== Object(value1)) {
     // non equal primitives
-    return false;
+    return false
   }
   if (!value1) {
-    return false;
+    return false
   }
   if (Array.isArray(value1)) {
-    return compareArrays(value1, value2);
+    return compareArrays(value1, value2)
   }
+
+  /* eslint-disable eqeqeq */
   if ({}.toString.call(value1) == '[object Object]') {
-    return compareObjects(value1, value2);
-  } else {
-    return compareNativeSubtypes(value1, value2);
+    return compareObjects(value1, value2)
   }
+  return compareNativeSubtypes(value1, value2)
 }
 
-function compareNativeSubtypes(value1, value2) {
+function compareNativeSubtypes (value1, value2) {
   // e.g. Function, RegExp, Date
-  return value1.toString() === value2.toString();
+  /* eslint-disable eqeqeq */
+  return value1.toString() == value2.toString()
 }
 
-function compareArrays(value1, value2) {
-  var len = value1.length;
+function compareArrays (value1, value2) {
+  const len = value1.length
   if (len != value2.length) {
-    return false;
+    return false
   }
-  var alike = true;
-  for (var i = 0; i < len; i++) {
+  let alike = true
+  for (let i = 0; i < len; i++) {
     if (!compare(value1[i], value2[i])) {
-      alike = false;
-      break;
+      alike = false
+      break
     }
   }
-  return alike;
+  return alike
 }
 
-function compareObjects(value1, value2) {
-  var keys1 = Object.keys(value1).sort();
-  var keys2 = Object.keys(value2).sort();
-  var len = keys1.length;
+function compareObjects (value1, value2) {
+  const keys1 = Object.keys(value1).sort()
+  const keys2 = Object.keys(value2).sort()
+  const len = keys1.length
   if (len != keys2.length) {
-    return false;
+    return false
   }
-  for (var i = 0; i < len; i++) {
-    var key1 = keys1[i];
-    var key2 = keys2[i];
+  for (let i = 0; i < len; i++) {
+    const key1 = keys1[i]
+    const key2 = keys2[i]
     if (!(key1 == key2 && compare(value1[key1], value2[key2]))) {
-      return false;
+      return false
     }
   }
-  return true;
+  return true
 }


### PR DESCRIPTION
This adds 2 new utils:
- compare
- clone

I saw a previous issue where you did not want to include lodash, so I added these 2 utils from the[ `just` library](https://github.com/angus-c/just)

I also ran a benchmark on them and they run significantly faster. Hoping this can be released as a v6 patch. Are there any unit tests to ensure behavior is the same @tannerlinsley ?