### PR TITLE
Fix pagination resetting to page zero with manualPagination

### DIFF
--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
 
 //
@@ -23,6 +23,7 @@ export const usePagination = props => {
   const {
     rows,
     manualPagination,
+    disablePageResetOnDataChange,
     debug,
     state: [
       {
@@ -37,6 +38,17 @@ export const usePagination = props => {
     ]
   } = props
 
+  const rowDep = disablePageResetOnDataChange ? null : rows
+  useLayoutEffect(() => {
+    setState(
+      old => ({
+        ...old,
+        pageIndex: 0
+      }),
+      actions.pageChange
+    )
+  }, [setState, rowDep, filters, groupBy, sortBy])
+  
   const { pages, pageCount } = useMemo(() => {
     if (manualPagination) {
       return {

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,4 +1,4 @@
-import { useMemo, useLayoutEffect } from 'react'
+import { useMemo } from 'react'
 import PropTypes from 'prop-types'
 
 //
@@ -36,16 +36,6 @@ export const usePagination = props => {
       setState
     ]
   } = props
-
-  useLayoutEffect(() => {
-    setState(
-      old => ({
-        ...old,
-        pageIndex: 0
-      }),
-      actions.pageChange
-    )
-  }, [rows, filters, groupBy, sortBy])
 
   const { pages, pageCount } = useMemo(() => {
     if (manualPagination) {


### PR DESCRIPTION
To be honest I'm not sure what this useLayoutEffect is there to do.
It has no visible effect if you don't use manualPagination, and if you
do it, simply jumps you back to the first page, defeating the point of
you having control of the pagination.