### PR TITLE
Provide option to toggle sort like V6

### DIFF
--- a/src/hooks/useSortBy.js
+++ b/src/hooks/useSortBy.js
@@ -29,7 +29,8 @@ const propTypes = {
   manualSorting: PropTypes.bool,
   disableSorting: PropTypes.bool,
   defaultSortDesc: PropTypes.bool,
-  disableMultiSort: PropTypes.bool
+  disableMultiSort: PropTypes.bool,
+  disableSortRemove: PropTypes.bool
 }
 
 export const useSortBy = props => {
@@ -44,6 +45,7 @@ export const useSortBy = props => {
     manualSorting,
     disableSorting,
     defaultSortDesc,
+    disableSortRemove,
     hooks,
     state: [{ sortBy }, setState]
   } = props
@@ -84,7 +86,7 @@ export const useSortBy = props => {
         if (sortBy.length <= 1 && existingSortBy) {
           if ((existingSortBy.desc && !resolvedDefaultSortDesc) ||
             (!existingSortBy.desc && resolvedDefaultSortDesc)) {
-            action = 'remove'
+            action = disableSortRemove? 'toggle' : 'remove'
           } else {
             action = 'toggle'
           }


### PR DESCRIPTION
V7 adds the option to remove a sort option, so it goes from asc -> desc
-> unset, then repeats.  V6 just went from asc -> desc then repeated.

Personally I much preferred this, I think that there's a case to be made
that this is the more expected behavior.

I'm not sure if this is really the best way to fix this since it adds
yet another api option and I completely understand that that is less
than desirable, but I also would rather add an option than have to
duplicate the whole useSortBy hook.