### PR TITLE
Fix useExpanded wrongly flattening subRows

### DIFF
--- a/src/hooks/useExpanded.js
+++ b/src/hooks/useExpanded.js
@@ -21,7 +21,6 @@ export const useExpanded = props => {
 
   const {
     debug,
-    columns,
     rows,
     expandedKey = 'expanded',
     hooks,
@@ -48,8 +47,6 @@ export const useExpanded = props => {
   const expandedRows = useMemo(() => {
     if (debug) console.info('getExpandedRows')
 
-    const expandedRows = []
-
     // Here we do some mutation, but it's the last stage in the
     // immutable process so this is safe
     const handleRow = (row, index, depth = 0, parentPath = []) => {
@@ -62,17 +59,15 @@ export const useExpanded = props => {
       row.isExpanded =
         (row.original && row.original[expandedKey]) || getBy(expanded, path)
 
-      expandedRows.push(row)
-
       if (row.isExpanded && row.subRows && row.subRows.length) {
         row.subRows.forEach((row, i) => handleRow(row, i, depth + 1, path))
       }
+
+      return row
     }
 
-    rows.forEach((row, i) => handleRow(row, i))
-
-    return expandedRows
-  }, [rows, expanded, columns])
+    return rows.map((row, i) => handleRow(row, i))
+  }, [debug, rows, expandedKey, expanded])
 
   const expandedDepth = findExpandedDepth(expanded)
 

--- a/src/hooks/useExpanded.js
+++ b/src/hooks/useExpanded.js
@@ -13,7 +13,8 @@ addActions({
 })
 
 const propTypes = {
-  expandedKey: PropTypes.string
+  expandedKey: PropTypes.string,
+  paginateSubRows: PropTypes.bool
 }
 
 export const useExpanded = props => {
@@ -24,7 +25,8 @@ export const useExpanded = props => {
     rows,
     expandedKey = 'expanded',
     hooks,
-    state: [{ expanded }, setState]
+    state: [{ expanded }, setState],
+    paginateSubRows = true
   } = props
 
   const toggleExpandedByPath = (path, set) => {
@@ -47,6 +49,8 @@ export const useExpanded = props => {
   const expandedRows = useMemo(() => {
     if (debug) console.info('getExpandedRows')
 
+    const expandedRows = []
+
     // Here we do some mutation, but it's the last stage in the
     // immutable process so this is safe
     const handleRow = (row, index, depth = 0, parentPath = []) => {
@@ -59,6 +63,10 @@ export const useExpanded = props => {
       row.isExpanded =
         (row.original && row.original[expandedKey]) || getBy(expanded, path)
 
+      if (paginateSubRows || (!paginateSubRows && row.depth === 0)) {
+        expandedRows.push(row)
+      }
+
       if (row.isExpanded && row.subRows && row.subRows.length) {
         row.subRows.forEach((row, i) => handleRow(row, i, depth + 1, path))
       }
@@ -66,8 +74,10 @@ export const useExpanded = props => {
       return row
     }
 
-    return rows.map((row, i) => handleRow(row, i))
-  }, [debug, rows, expandedKey, expanded])
+    rows.forEach((row, i) => handleRow(row, i))
+
+    return expandedRows
+  }, [debug, rows, expandedKey, expanded, paginateSubRows])
 
   const expandedDepth = findExpandedDepth(expanded)
 


### PR DESCRIPTION
Hey guys,

Here is a PR that fixes `useExpanded` that was not usable at the moment. The reason is that all the `subRows` were flattened at the root level. Which was breaking the `usePagination` component.
Now the rows are correctly nested and pagination works fine.

What is did is the following:

**Before**
```
[
  { id: 'row-0' }
  { id: 'row-0-0' }
  { id: 'row-1' }
  { id: 'row-2' }
  { id: 'row-3' }
]
```

**After**
```
[
  { 
    id: 'row-0', 
    subRows: [
      { id: 'row-0-0' } 
    ] 
  }
  { id: 'row-1' }
  { id: 'row-2' }
  { id: 'row-3' }
]
```

Please see the following code sandbox with a working example: https://codesandbox.io/s/react-table-v7-sandbox-8wr0e

![Screenshot 2019-06-20 at 12 42 17](https://user-images.githubusercontent.com/527559/59862324-efbc2200-9358-11e9-9f4f-51b90b43ff60.jpg)
