### PR TITLE
Add support for es module build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "datagrid"
   ],
   "main": "dist/index.js",
-  "_module": "dist/index.es.js",
-  "_jsnext:main": "dist/index.es.js",
+  "module": "dist/index.es.js",
+  "jsnext:main": "dist/index.es.js",
   "scripts": {
     "test": "cross-env CI=1 react-scripts test --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,27 +6,36 @@ import { uglify } from 'rollup-plugin-uglify'
 
 import pkg from './package.json'
 
-export default {
-  input: 'src/index.js',
-  output: [
-    {
+export default [
+  {
+    input: 'src/index.js',
+    output: {
       file: pkg.main,
       format: 'cjs',
       sourcemap: true
-    }
-    // {
-    //   file: pkg.module,
-    //   format: "es",
-    //   sourcemap: true
-    // }
-  ],
-  plugins: [
-    external(),
-    babel({
-      exclude: 'node_modules/**'
-    }),
-    resolve(),
-    commonjs(),
-    uglify()
-  ]
-}
+    },
+    plugins: [
+      external(),
+      babel({
+        exclude: 'node_modules/**'
+      }),
+      resolve(),
+      commonjs(),
+      uglify()
+    ]
+  },
+  {
+    input: 'src/index.js',
+    external: Object.keys(pkg.peerDependencies),
+    output: {
+      file: pkg.module,
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: [
+      babel({
+        exclude: ['/**/node_modules/**']
+      })
+    ]
+  }
+]


### PR DESCRIPTION
Hi Tanner,

Here is a PR that provides an ESM build to the tools that support it.
For example Webpack now uses the `.es` version of the library instead of the umd one, making things lighter.

Hope this helps,