### PR TITLE
Fixed grouped column Header that were not adjusting based on hidden child columns

### DIFF
--- a/src/hooks/useColumns.js
+++ b/src/hooks/useColumns.js
@@ -114,7 +114,7 @@ export const useColumns = props => {
     const recurse = columns => {
       columns.forEach(d => {
         if (!d[childKey]) {
-          flatColumns.push(d)
+          if (d.show === undefined || d.show) flatColumns.push(d)
         } else {
           recurse(d[childKey])
         }

--- a/src/hooks/useColumns.js
+++ b/src/hooks/useColumns.js
@@ -114,7 +114,7 @@ export const useColumns = props => {
     const recurse = columns => {
       columns.forEach(d => {
         if (!d[childKey]) {
-          if (d.show === undefined || d.show) flatColumns.push(d)
+          flatColumns.push(d)
         } else {
           recurse(d[childKey])
         }

--- a/src/hooks/useFlexLayout.js
+++ b/src/hooks/useFlexLayout.js
@@ -127,7 +127,7 @@ function getSizesForColumn(
 ) {
   if (columns) {
     columns = columns
-      .filter(col => col.visible)
+      .filter(col => col.show || col.visible)
       .map(column =>
         getSizesForColumn(column, columnMeasurements, defaultFlex, api)
       )

--- a/src/hooks/useFlexLayout.js
+++ b/src/hooks/useFlexLayout.js
@@ -127,6 +127,7 @@ function getSizesForColumn(
 ) {
   if (columns) {
     columns = columns
+      .filter(col => col.visible)
       .map(column =>
         getSizesForColumn(column, columnMeasurements, defaultFlex, api)
       )


### PR DESCRIPTION
The grouped header columns are not adjusting width if child columns update their `show` property.  This is because the Headers are basing their width on the sum of the child columns, but not factoring in the `show` property.

You can see an example below.  I added a button to toggle the fix on and off.

https://codesandbox.io/s/react-table-v7-sandbox-2qyr4
