### PR TITLE
getRowProps preserve param order

### DIFF
--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -190,7 +190,7 @@ export const useTable = (props, ...plugins) => {
     mergeProps(applyPropHooks(api.hooks.getTableProps, api), userProps)
 
   api.getRowProps = userProps =>
-    mergeProps(applyPropHooks(api.hooks.getRowProps, api), userProps)
+    mergeProps(applyPropHooks(api.hooks.getRowProps, undefined, api), userProps)
 
   return api
 }


### PR DESCRIPTION
Added undefined to` unspecific getRowProps`  fn because `api` param replaces the context of `row`.

See this ticket for more info:  https://github.com/tannerlinsley/react-table/issues/1388