### PR TITLE
[v6] getTfootTdProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ These are all of the available props (and their default values) for the main `<R
   getTdProps: () => ({}),
   getTfootProps: () => ({}),
   getTfootTrProps: () => ({}),
-  getTfootThProps: () => ({}),
+  getTfootTdProps: () => ({}),
   getPaginationProps: () => ({}),
   getLoadingProps: () => ({}),
   getNoDataProps: () => ({}),

--- a/src/index.js
+++ b/src/index.js
@@ -737,7 +737,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
       const show = typeof column.show === 'function' ? column.show() : column.show
       const width = _.getFirstDefined(resizedCol.value, column.width, column.minWidth)
       const maxWidth = _.getFirstDefined(resizedCol.value, column.width, column.maxWidth)
-      const tFootTdProps = _.splitProps(getTfootTdProps(finalState, undefined, undefined, this))
+      const tFootTdProps = _.splitProps(getTfootTdProps(finalState, undefined, column, this))
       const columnProps = _.splitProps(column.getProps(finalState, undefined, column, this))
       const columnFooterProps = _.splitProps(
         column.getFooterProps(finalState, undefined, column, this)


### PR DESCRIPTION
The documentation mentions a [`getTfootThProps` prop](https://github.com/tannerlinsley/react-table/tree/v6#props) but it does not exist in the code anywhere. Instead there is the `getTfootTdProps` prop. So I corrected that in the docs.

Also, I noticed that `getTfootTdProps` is missing the `column` argument. All other similar functions in that scope (as well as the `getTheadThProps`) do have it. So I added it. This also (partially) fixes #1120.