### PR TITLE
Small readme example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ function MyTable({ columns, data }) {
     <table {...getTableProps()}>
       <thead>
         {headerGroups.map(headerGroup => (
-          <tr {...headerGroup.getRowProps()}>
+          <tr {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map(column => (
               <th {...column.getHeaderProps()}>{column.render('Header')}</th>
             ))}


### PR DESCRIPTION
in commit ea79cd838891a21db6754c387a73d3ea4fffd127 the`getRowProps` member of the headerGroup object changed into `getHeaderGroupProps`

The example in readme still referenced the old `getRowProps`, I think this should be updated to `getHeaderGroupProps`.