### PR TITLE
fix(utils): default Cell renderer cleanup

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -39,7 +39,7 @@ export function decorateColumn(column, defaultColumn, parent, depth, index) {
 
   column = {
     Header: () => null,
-    Cell: ({ value }) => (typeof value !== 'undefined' ? value : ''),
+    Cell: ({ value = '' }) => value,
     show: true,
     ...column,
     id,


### PR DESCRIPTION
Just a small improvement leveraging default parameter instead of `typeof`