### PR TITLE
[v7] useSort - Multisort functionality: Limit max cols and optional shift key

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,10 @@ The following options are supported via the main options object passed to `useTa
   - Disables sorting for every column in the entire table.
 - `disableMultiSort: Bool`
   - Disables multi-sorting for the entire table.
+- `enableMultiSortWithoutShift: Bool`
+  - Setting this flag to true makes pressing shift key as optional for multi-sorting.
+- `maxMultiSortColCount: Number`
+  - Limit on max number of columns for multisort, e.g. if set to 3, and suppose table is sorted by `[A, B, C]` and then clicking `D` for sorting should result in table sorted by `[B, C , D]`
 - `disableSortRemove: Bool`
   - If true, the un-sorted state will not be available to columns once they have been sorted.
 - `disableMultiRemove: Bool`

--- a/README.md
+++ b/README.md
@@ -566,8 +566,9 @@ The following options are supported via the main options object passed to `useTa
   - Disables sorting for every column in the entire table.
 - `disableMultiSort: Bool`
   - Disables multi-sorting for the entire table.
-- `enableMultiSortWithoutShift: Bool`
-  - Setting this flag to true makes pressing shift key as optional for multi-sorting.
+- `isMultiSortEvent: Function`
+  - Allows to override default multisort behaviour(i.e. multisort applies when shift key is presssed), if this function is provided then returned boolean value from this function will make decision whether newly applied sort action will be considered as multisort or not.
+  - Receives `event` as argument.
 - `maxMultiSortColCount: Number`
   - Limit on max number of columns for multisort, e.g. if set to 3, and suppose table is sorted by `[A, B, C]` and then clicking `D` for sorting should result in table sorted by `[B, C , D]`
 - `disableSortRemove: Bool`

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -31,6 +31,8 @@ const propTypes = {
   manualSorting: PropTypes.bool,
   disableSorting: PropTypes.bool,
   disableMultiSort: PropTypes.bool,
+  enableMultiSortWithoutShift: PropTypes.bool,
+  maxMultiSortColCount: PropTypes.number, 
   disableSortRemove: PropTypes.bool,
   disableMultiRemove: PropTypes.bool,
 }
@@ -55,6 +57,8 @@ function useMain(instance) {
     disableSortRemove,
     disableMultiRemove,
     disableMultiSort,
+    enableMultiSortWithoutShift = false,
+    maxMultiSortColCount = Number.MAX_SAFE_INTEGER,
     hooks,
     state: [{ sortBy }, setState],
     plugins,
@@ -145,6 +149,8 @@ function useMain(instance) {
             desc: hasDescDefined ? desc : sortDescFirst,
           },
         ]
+        // Take latest n columns
+        newSortBy.splice(0, newSortBy.length - maxMultiSortColCount);
       } else if (action === 'toggle') {
         // This flips (or sets) the
         newSortBy = sortBy.map(d => {
@@ -194,7 +200,7 @@ function useMain(instance) {
                 e.persist()
                 column.toggleSortBy(
                   undefined,
-                  !instance.disableMultiSort && e.shiftKey
+                  !instance.disableMultiSort && (enableMultiSortWithoutShift || e.shiftKey)
                 )
               }
             : undefined,

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -31,7 +31,7 @@ const propTypes = {
   manualSorting: PropTypes.bool,
   disableSorting: PropTypes.bool,
   disableMultiSort: PropTypes.bool,
-  enableMultiSortWithoutShift: PropTypes.bool,
+  isMultiSortEvent: PropTypes.func,
   maxMultiSortColCount: PropTypes.number, 
   disableSortRemove: PropTypes.bool,
   disableMultiRemove: PropTypes.bool,
@@ -57,7 +57,7 @@ function useMain(instance) {
     disableSortRemove,
     disableMultiRemove,
     disableMultiSort,
-    enableMultiSortWithoutShift = false,
+    isMultiSortEvent = (e) => e.shiftKey,
     maxMultiSortColCount = Number.MAX_SAFE_INTEGER,
     hooks,
     state: [{ sortBy }, setState],
@@ -200,7 +200,7 @@ function useMain(instance) {
                 e.persist()
                 column.toggleSortBy(
                   undefined,
-                  !instance.disableMultiSort && (enableMultiSortWithoutShift || e.shiftKey)
+                  !instance.disableMultiSort && isMultiSortEvent(e)
                 )
               }
             : undefined,


### PR DESCRIPTION
1. Provide configuration for multisort that pressing shift key is not compulsory

2. Configurable limit on max number of columns for multisort, like configuration has been provided that `maxMultiSortColCount` is 3, suppose currenlty table is sorted by `[A, B, C]` and then clicking `D` for sorting should result in table sorted by `[B, C , D]`