### PR TITLE
fix(use-sort-by): sorting now ignores column ids that no longer exist

### DIFF
--- a/src/plugin-hooks/useFilters.js
+++ b/src/plugin-hooks/useFilters.js
@@ -146,12 +146,12 @@ function useMain(instance) {
           // Find the filters column
           const column = columns.find(d => d.id === columnID)
 
-          if (depth === 0) {
-            column.preFilteredRows = filteredSoFar
-          }
-
           if (!column) {
             return filteredSoFar
+          }
+
+          if (depth === 0) {
+            column.preFilteredRows = filteredSoFar
           }
 
           const filterMethod = getFilterMethod(


### PR DESCRIPTION
I have a table that dynamically generates columns (there is a switch that transposes rows to columns and vice versa). However if I sort the existing table and then click that "switch" button, I'm getting error `Cannot read property 'sortType' of undefined`, because the column by which the content was sorted before no longer exists. This PR fixes this issue - if the column no longer exists, the sorting function for it always returns 0 (so the items stay in its original place). I don't remove them from `sortBy` state, because, as I said, my table has a switch, so if I go back to previous view it will keep the sorting that I set before switching. It works the same way with filters, so I think it's fine.

By the way, I'd recommend installing Prettier as dev dependency instead of relying on globally installed one (I suppose that's how it works right now) - I modified only small part of this file but it reformatted much more than that and I guess it's because of version mismatch - I didn't have Prettier installed globally and I had to install the latest one. But that's a topic for a separate PR most likely.

edit: It seems like in alpha.22 it doesn't work with filters as well... I can prepare a separate PR for that too but now I'm not even sure if you want to support this kind of behavior, though I think in any case the component should not completely fail...