### PR TITLE
fix: replace 'outline: none' with 'outline-width: 0'

### DIFF
--- a/src/index.styl
+++ b/src/index.styl
@@ -9,7 +9,7 @@ input-select-style()
   font-size: inherit
   border-radius: 3px
   font-weight: normal
-  outline:none
+  outline-width: 0
 
 .ReactTable
   position:relative
@@ -74,7 +74,7 @@ input-select-style()
         border-right: 0
 
     .rt-th:focus
-      outline: none
+      outline-width: 0
 
     .rt-resizable-header
       overflow: visible
@@ -230,7 +230,7 @@ input-select-style()
       background: alpha(black, .1)
       transition: all .1s ease
       cursor: pointer
-      outline:none
+      outline-width: 0
 
       &[disabled]
         opacity: .5


### PR DESCRIPTION
Replace outline: none with outline-width: 0 to allow reset of outline styles to default browser settings. Closes #1471