### PR TITLE
fix field names in useSortBy docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -434,12 +434,12 @@ The following properties are available on every `Column` object returned by the 
   - This function is used to resolve any props needed for this column's UI that is responsible for toggling the sort direction when the user clicks it.
   - You can use the `getSortByToggleProps` hook to extend its functionality.
   - Custom props may be passed. **NOTE: Custom props may override built-in sortBy props, so be careful!**
-- `sorted: Boolean`
+- `isSorted: Boolean`
   - Denotes whether this column is currently being sorted
 - `sortedIndex: Int`
   - If the column is currently sorted, this integer will be the index in the `sortBy` array from state that corresponds to this column.
   - If this column is not sorted, the index will always be `-1`
-- `sortedDesc: Bool`
+- `isSortedDesc: Bool`
   - If the column is currently sorted, this denotes whether the column's sort direction is descending or not.
   - If `true`, the column is sorted `descending`
   - If `false`, the column is sorted `ascending`
@@ -473,10 +473,10 @@ function Table({ columns, data }) {
                 <span>
                   {/* Add a sort direction indicator */}
                   <span>
-                    {column.sorted ? (column.sortedDesc ? ' 🔽' : ' 🔼') : ''}
+                    {column.isSorted ? (column.isSortedDesc ? ' 🔽' : ' 🔼') : ''}
                   </span>
                   {/* Add a sort index indicator */}
-                  <span>({column.sorted ? column.sortedIndex + 1 : ''})</span>
+                  <span>({column.isSorted ? column.sortedIndex + 1 : ''})</span>
                 </span>
               </th>
             ))}


### PR DESCRIPTION
This fixes an error in the documentation for `useSortBy`, where it says columns will have `sorted` and `sortedDesc` fields to denote sort state. The current implementation, however, uses `isSorted` and `isSortedDesc` as the field names: https://github.com/tannerlinsley/react-table/blob/4537f28a8d3b304b03fa6bd752fb99025130573d/src/plugin-hooks/useSortBy.js#L202-L204.