### PR TITLE
Fixing react warnings

### DIFF
--- a/src/hoc/advancedExpandTable/index.js
+++ b/src/hoc/advancedExpandTable/index.js
@@ -66,7 +66,7 @@ export const advancedExpandTableHOC = TableComponent =>
     // after initial render if we get new
     // data, columns, page changes, etc.
     // we reset expanded state.
-    componentWillReceiveProps () {
+    UNSAFE_componentWillReceiveProps () {
       this.setState({
         expanded: {},
       })

--- a/src/hoc/foldableTable/index.js
+++ b/src/hoc/foldableTable/index.js
@@ -41,7 +41,7 @@ export default ReactTable => {
       }
     }
 
-    componentWillReceiveProps(newProps) {
+    UNSAFE_componentWillReceiveProps(newProps) {
       if (this.state.resized !== newProps.resized) {
         this.setState(p => ({ resized: newProps.resized }))
       }

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,6 +1,6 @@
 export default Base =>
   class extends Base {
-    componentWillMount () {
+    UNSAFE_componentWillMount () {
       this.setStateWithData(this.getDataModel(this.getResolvedState(), true))
     }
 
@@ -8,7 +8,7 @@ export default Base =>
       this.fireFetchData()
     }
 
-    componentWillReceiveProps (nextProps, nextState) {
+    UNSAFE_componentWillReceiveProps (nextProps, nextState) {
       const oldState = this.getResolvedState()
       const newState = this.getResolvedState(nextProps, nextState)
 

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -63,7 +63,7 @@ export default class ReactTablePagination extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.page !== nextProps.page) {
       this.setState({ page: nextProps.page })
     }


### PR DESCRIPTION
React 16.9.0(and upwards) deprecated usage of `componentWillMount` and `componentWillReceiveProps`.

This pr renames the methods to use the renamed UNSAFE ones. It suppresses the warnings. As you guys have decided to not continue working on v6, I guess this is the best we can do.

Edit: I've seen you guys still support React 15.x in package.json. Can we drop the support and only support React v16? This would make this fix much easier.