### PR TITLE
use getPrototypeOf instead of .prototype

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -218,7 +218,7 @@ function normalizeComponent (Comp, params = {}, fallback = Comp) {
 function isClassComponent (component) {
   return !!((
     typeof component === 'function' &&
-      !!component.prototype.isReactComponent
+      !!Object.getPrototypeOf(component).isReactComponent
   ))
 }
 


### PR DESCRIPTION
This fixes an issue using arrow functions for custom `Cell`s introduced in the latest release 

Issue: #1502