### PR TITLE
isAllRowsSelected can only be true if there are rows.

### DIFF
--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -38,7 +38,7 @@ function useMain(instance) {
     []
   )
 
-  const isAllRowsSelected = rowPaths.length === selectedRows.length
+  const isAllRowsSelected = rowPaths.length > 0 && rowPaths.length === selectedRows.length
 
   const toggleRowSelectedAll = set => {
     setState(old => {


### PR DESCRIPTION
When using the useRowSelect hook if you had no rows in the table `isAllRowsSelected` would be `true` as the number of selected rows equals the number of rows and a checkbox will be checked. This shouldn't be the case. You can preview the issue [here](https://codesandbox.io/s/tannerlinsleyreact-table-row-selection-qizrj).
This is just a simple fix for that issue.