### PR TITLE
Incorrect TypeScript typings specified in EnhancedColumn interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,8 +48,8 @@ declare module 'react-table' {
         render: (type: string) => any;
         getHeaderProps: (userProps?: any) => any;
         getSortByToggleProps: (userProps?: any) => any;
-        sorted: boolean;
-        sortedDesc: boolean;
+        isSorted: boolean;
+        isSortedDesc: boolean;
         sortedIndex: number;
     }
 


### PR DESCRIPTION
Whilst working with the useSortBy hook in a TypeScript project I found that the EnhancedColumn isSorted and isSortedDesc properties were not working.

Upon investigating this issue I found that these properties had been incorrectly specified in the typings file. This PR fixes that issue.