### PR TITLE
add canSort and canFilter column properties support

### DIFF
--- a/src/plugin-hooks/useFilters.js
+++ b/src/plugin-hooks/useFilters.js
@@ -107,16 +107,23 @@ function useMain(instance) {
   }
 
   flatColumns.forEach(column => {
-    const { id, accessor, disableFilters: columnDisableFilters } = column
+    const {
+      id,
+      accessor,
+      canFilter,
+      disableFilters: columnDisableFilters,
+    } = column
 
     // Determine if a column is filterable
-    column.canFilter = accessor
-      ? getFirstDefined(
-          columnDisableFilters === true ? false : undefined,
-          disableFilters === true ? false : undefined,
-          true
-        )
-      : false
+    if (canFilter === undefined) {
+      column.canFilter = accessor
+        ? getFirstDefined(
+            columnDisableFilters === true ? false : undefined,
+            disableFilters === true ? false : undefined,
+            true
+          )
+        : false
+    }
 
     // Provide the column a way of updating the filter value
     column.setFilter = val => setFilter(column.id, val)

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -161,17 +161,22 @@ function useMain(instance) {
 
   // Add the getSortByToggleProps method to columns and headers
   flatHeaders.forEach(column => {
-    const { accessor, disableSorting: columnDisableSorting, id } = column
+    const {
+      accessor,
+      canSort,
+      disableSorting: columnDisableSorting,
+      id,
+    } = column
 
-    const canSort = accessor
-      ? getFirstDefined(
-          columnDisableSorting === true ? false : undefined,
-          disableSorting === true ? false : undefined,
-          true
-        )
-      : false
-
-    column.canSort = canSort
+    if (canSort === undefined) {
+      column.canSort = accessor
+        ? getFirstDefined(
+            columnDisableSorting === true ? false : undefined,
+            disableSorting === true ? false : undefined,
+            true
+          )
+        : false
+    }
 
     if (column.canSort) {
       column.toggleSortBy = (desc, multi) =>
@@ -192,7 +197,7 @@ function useMain(instance) {
     column.getSortByToggleProps = props => {
       return mergeProps(
         {
-          onClick: canSort
+          onClick: column.canSort
             ? e => {
                 e.persist()
                 column.toggleSortBy(
@@ -202,7 +207,7 @@ function useMain(instance) {
               }
             : undefined,
           style: {
-            cursor: canSort ? 'pointer' : undefined,
+            cursor: column.canSort ? 'pointer' : undefined,
           },
           title: 'Toggle SortBy',
         },


### PR DESCRIPTION
Added support for `canSort` and `canFilter` properties for columns

This should cover this issue https://github.com/tannerlinsley/react-table/issues/1538