### PR TITLE
Fix isClassComponent function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -288,7 +288,10 @@ export function flexRender(Comp, props) {
 function isClassComponent(component) {
   return (
     typeof component === 'function' &&
-    !!Object.getPrototypeOf(component).isReactComponent
+    !!(() => {
+      let proto = Object.getPrototypeOf(component)
+      return proto.prototype && proto.prototype.isReactComponent
+    })()
   )
 }
 


### PR DESCRIPTION
`Object.getPrototypeOf(component)` returns React `Component()` function itself, not a prototype of `Component` but `isReactComponent` is a property of `Component.prototype`.

So correct check here is `Component.prototype.isReactComponent` not `Component.isReactComponent`.