### PR TITLE
docs(readme): adds a react-table-v6 package note

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Please [visit the v6 branch](https://github.com/tannerlinsley/react-table/tree/v
 
 The differences between the 2 versions are incredibly massive. Unfortunately, I cannot write a one-to-one upgrade guide for any of v6's API, simply because much of it is irrelevant with v7's headless approach. The best approach for migrating to v7 is to learn its API by reading the documentation and then following some of the examples to begin building your own table component.
 
+In case you would need to have both v6 and v7 in one app during the migration process (large codebase, complex use cases), you can install an official [`react-table-v6` package](https://www.npmjs.com/package/react-table-v6) alongside the `react-table`.
+
 ## Documentation
 
 - [Installation](./docs/installation.md) - Walk through how to install React Table


### PR DESCRIPTION
Creating this PR after a discussion at https://spectrum.chat/react-table/general/additional-package-just-for-the-v7~7115661c-7e60-4a61-a16f-4be7e6796349

TL;DR: right now the migration process from v6 to v7 can be complicated due to the v7 being completely different from v6, so at a larger codebase you could need to have both versions installed at the same time. While this is possible to do right now, by using an alias like `npm:react-table@6.8.6`, if you're using TypeScript things could become much more complicated as both packages would have the `react-table` as a module name.

My proposal is to push a legacy `react-table-v6` package to the registry with the latest version of v6 and a changed module name in the TS definition. This would allow us to use both v6 and v7 versions at the same time without any problems just by replacing the old v6 version by this `react-table-v6` package and then using the original `react-table` only for the v7 version.

While this can also be solved by a fork, I feel that given the v6 popularity this can be an issue for more people, and I feel that creating such package would be the best solution (and wouldn't need a lot of maintaining).

This PR adds a line to the README about this package, and, of course, should be merged only if this idea is accepted by the project's maintainers and after they would publish the corresponding package.

Thank you for `react-table` and the very promising v7 rewrite, it is an awesome project!