### PR TITLE
Update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -200,6 +200,7 @@ declare module 'react-table' {
     headerGroups: HeaderGroup<D>[]
     headers: HeaderGroup<D>[]
     getTableProps: (userProps?: any) => any
+    getTableBodyProps: (userProps?: any) => any
     getRowProps: (userProps?: any) => any
     prepareRow: (row: Row<D>) => any
     state: TableState<D>
@@ -210,7 +211,7 @@ declare module 'react-table' {
     data: D[]
     columns: HeaderColumn<D>[]
     debug?: boolean
-    loading: boolean
+    loading?: boolean
     defaultColumn?: Partial<Column<D>>
     initialState?: Partial<TableState<D>>
     state?: Partial<TableState<D>>


### PR DESCRIPTION
Running the basic example in a typescript file I have two issue so far
1. loading property is required when useTable() is called
```
Property 'loading' is missing in type '{ columns: Column<any>[]; data: any[]; }' but required in type 'TableOptions<any>'.
```
That's why I made it optional

2. getTableBodyProps is not added in typings
```
Property 'getTableBodyProps' does not exist on type 'TableInstance<any>'.
```