### PR TITLE
fix(usegroupby): column.disableGrouping inverted logic

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -575,8 +575,8 @@ The following options are supported on any `Column` object passed to the `column
   - Must return valid JSX
   - This function (or component) formats this column's value when it is being grouped and aggregated, eg. If this column was showing the number of visits for a user to a website and it was currently being grouped to show an **average** of the values, the `Aggregated` function for this column could format that value to `1,000 Avg. Visits`
 - `disableGrouping: Boolean`
-  - Defaults to `true`
-  - If `true`, this column is able to be grouped.
+  - Defaults to `false`
+  - If `true`, will disable grouping for this column.
 
 ### Instance Properties
 

--- a/src/plugin-hooks/useGroupBy.js
+++ b/src/plugin-hooks/useGroupBy.js
@@ -93,7 +93,7 @@ function useMain(instance) {
 
     column.canGroupBy = accessor
       ? getFirstDefined(
-          columnDisableGrouping,
+          columnDisableGrouping === true ? false : undefined,
           disableGrouping === true ? false : undefined,
           true
         )


### PR DESCRIPTION
unlike other hooks, the column.disableGrouping actually enabled grouping for a column