### PR TITLE
remove Record from HeaderProps and CellProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -159,12 +159,13 @@ export interface UseTableCellProps<D extends object> {
 
 export type HeaderProps<D extends object> = TableInstance<D> & {
   column: ColumnInstance<D>
-} & Record<string, any>
+}
+
 export type CellProps<D extends object> = TableInstance<D> & {
   column: ColumnInstance<D>
   row: Row<D>
   cell: Cell<D>
-} & Record<string, any>
+}
 
 // NOTE: At least one of (id | accessor | Header as string) required
 export interface Accessor<D extends object> {


### PR DESCRIPTION
These definitions mask errors in the other definitions and there are better
ways of extending these.

See https://github.com/tannerlinsley/react-table/pull/1597 for an
example of an existing prototype that was missing but harder to find
because of these definitions.