### PR TITLE
v6: prefer components in normalizeComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,10 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.0",
+    "prop-types": "^15.7.0",
     "react": "^16.x.x",
-    "react-dom": "^16.x.x"
+    "react-dom": "^16.x.x",
+    "react-is": "^16.8.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "docs:build": "yarn build && cd docs && yarn && yarn build"
   },
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "react-is": "^16.8.1"
   },
   "peerDependencies": {
     "prop-types": "^15.7.0",
     "react": "^16.x.x",
-    "react-dom": "^16.x.x",
-    "react-is": "^16.8.1"
+    "react-dom": "^16.x.x"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,11 @@ const config = {
     replace({
       'process.env.NODE_ENV': JSON.stringify(env),
     }),
-    commonjs(),
+    commonjs({
+      namedExports: {
+        'react-is': ['isValidElementType', 'isElement'],
+      },
+    }),
   ],
 }
 

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -82,14 +82,14 @@ export default {
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       // Renderers
-      Cell: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.func]),
-      Header: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.func]),
-      Footer: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.func]),
-      Aggregated: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.func]),
-      Pivot: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.func]),
-      PivotValue: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.func]),
-      Expander: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.func]),
-      Filter: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+      Cell: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.elementType]),
+      Header: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.elementType]),
+      Footer: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.elementType]),
+      Aggregated: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.elementType]),
+      Pivot: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.elementType]),
+      PivotValue: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.elementType]),
+      Expander: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.elementType]),
+      Filter: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
 
       // All Columns
       sortable: PropTypes.bool, // use table default

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
+import * as ReactIs from 'react-is'
+
 //
 export default {
   get,
@@ -204,24 +206,12 @@ function isSortingDesc (d) {
 }
 
 function normalizeComponent (Comp, props, fallback = Comp) {
-  return isReactComponent(Comp) ? <Comp {...props} /> : typeof Comp === 'function' ? Comp(props) : fallback
-}
+  if (ReactIs.isElement(Comp) || typeof Comp === 'string') {
+    return Comp
+  } else if (ReactIs.isValidElementType(Comp)) {
+    return <Comp {...props} />
+  }
 
-function isClassComponent (component) {
-  return (
-    typeof component === 'function' &&
-    !!Object.getPrototypeOf(component).isReactComponent
-  )
-}
-
-function isFunctionComponent (component) {
-  return (
-    typeof component === 'function' &&
-    String(component).includes('.createElement')
-  )
-}
-
-function isReactComponent (component) {
-  return isClassComponent(component) || isFunctionComponent(component)
+  return fallback
 }
 


### PR DESCRIPTION
We have been using v6.10.0 and one of our cell components was changed to use `React.memo` and the table unexpectedly stopped working. It looks like other have users reported issues with `normalizeComponent` in various versions and some fixes have been made. 

Unfortunately some users have code that assumes the "components" are just a element factory and not a true React component. When these React components are defined inline this can cause  unmounts when the parent component is re-rendered. This branch will not fix that issue but I think instead users should avoid creating inline components and just use React context if you absolutely need to provide anything to these components.

The fix for us was to use `isValidElementType` from `react-is` for component detection and allow us to use `React.memo`, `React.forwardRef`, etc. We think this solution is cleaner and providers a more predictable API. We weren't comfortable with the existing `String(component).includes('.createElement')` detection and have a lot of examples where that fails.

I understand that this probably won't be merged but it could be helpful for others that might fork this lib. Thanks!

Other changes
- updated `prop-types` peer dep to `^15.7.0` because that is when `elementType` was introduced
- add `react-is` peer dep
- update column "renderer" prop types to more closely reflect the new logic in `normalizeComponent`

