### PR TITLE
[useSort] Add sort order custom sortMethod

### DIFF
--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -268,7 +268,7 @@ function useMain(instance) {
 
           // Return the correct sortFn.
           // This function should always return in ascending order
-          return (a, b) => sortMethod(a, b, sort.id)
+          return (a, b) => sortMethod(a, b, sort.id, sort.desc)
         }),
         // Map the directions
         availableSortBy.map(sort => {


### PR DESCRIPTION
Added sort order as parameter for calling sortMethod(will be useful to provide more control in custom sortMethod)

Example :- To keep empty strings at bottom when sort in asc/desc order.

```
function stringSort(rowA, rowB, columnID, desc) {
  let a = getRowValueByColumnID(rowA, columnID);
  let b = getRowValueByColumnID(rowB, columnID);

  return compareBasic(a, b, desc);
}

function compareBasic(a, b, desc) {
  if (a === b) {
    return 0;
  }

  if (a === '') {
    return desc ? -1 : 1;
  }

  if (b === '') {
    return desc ? 1 : -1;
  }

  return a > b ? 1 : -1;
}
```
