### PR TITLE
avoid calling `setState` in constructor from lifecycle.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
   static defaultProps = defaultProps
 
   constructor (props) {
-    super()
+    super(props)
 
     this.getResolvedState = this.getResolvedState.bind(this)
     this.getDataModel = this.getDataModel.bind(this)

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,9 +1,9 @@
 export default Base =>
   class extends Base {
     constructor(props) {
-      super(props);
+      super(props)
 
-      this.setStateWithData(this.getDataModel(this.getResolvedState(), true))
+      this.state = this.calculateNewResolvedState(this.getDataModel(this.getResolvedState(), true))
     }
 
     componentDidMount () {
@@ -50,9 +50,9 @@ export default Base =>
       }
     }
 
-    setStateWithData (newState, cb) {
+    calculateNewResolvedState (dataModel) {
       const oldState = this.getResolvedState()
-      const newResolvedState = this.getResolvedState({}, newState)
+      const newResolvedState = this.getResolvedState({}, dataModel)
       const { freezeWhenExpanded } = newResolvedState
 
       // Default to unfrozen state
@@ -113,7 +113,11 @@ export default Base =>
         )
       }
 
-      return this.setState(newResolvedState, () => {
+      return newResolvedState
+    }
+
+    setStateWithData (dataModel, cb) {
+      return this.setState(this.calculateNewResolvedState(dataModel), () => {
         if (cb) {
           cb()
         }


### PR DESCRIPTION
I moved all the state-calculation logic into a separate method, so in constructor we are just using that to get the initial state. This should fix the issue introduced in #1536 