### PR TITLE
Remove void from flow control in examples

### DIFF
--- a/examples/absolute-layout/src/App.js
+++ b/examples/absolute-layout/src/App.js
@@ -94,7 +94,7 @@ function Table({ columns, data }) {
       <div className="rows" {...getTableBodyProps()}>
         {rows.map(
           (row, i) =>
-            prepareRow(row) || (
+            (prepareRow(row), (
               <div {...row.getRowProps()} className="row body">
                 {row.cells.map((cell,index) => (
                   <div {...cell.getCellProps()} key={index} className="cell">
@@ -102,7 +102,7 @@ function Table({ columns, data }) {
                   </div>
                 ))}
               </div>
-            )
+            ))
         )}
       </div>
     </div>

--- a/examples/animated-framer-motion/src/App.js
+++ b/examples/animated-framer-motion/src/App.js
@@ -269,7 +269,7 @@ function Table({ columns, data }) {
           <AnimatePresence>
             {rows.slice(0, 10).map(
               (row, i) =>
-                prepareRow(row) || (
+                (prepareRow(row), (
                   <motion.tr
                     {...row.getRowProps({
                       layoutTransition: spring,
@@ -288,7 +288,7 @@ function Table({ columns, data }) {
                       )
                     })}
                   </motion.tr>
-                )
+                ))
             )}
           </AnimatePresence>
         </tbody>

--- a/examples/basic/src/App.js
+++ b/examples/basic/src/App.js
@@ -61,13 +61,13 @@ function Table({ columns, data }) {
       <tbody {...getTableBodyProps()}>
         {rows.map(
           (row, i) =>
-            prepareRow(row) || (
+            (prepareRow(row), (
               <tr {...row.getRowProps()}>
                 {row.cells.map(cell => {
                   return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
                 })}
               </tr>
-            )
+            ))
         )}
       </tbody>
     </table>

--- a/examples/block-layout/src/App.js
+++ b/examples/block-layout/src/App.js
@@ -77,7 +77,7 @@ function Table({ columns, data }) {
       <div {...getTableBodyProps()}>
         {rows.map(
           (row, i) =>
-            prepareRow(row) || (
+            (prepareRow(row), (
               <div {...row.getRowProps()} className="tr">
                 {row.cells.map(cell => {
                   return (
@@ -87,7 +87,7 @@ function Table({ columns, data }) {
                   )
                 })}
               </div>
-            )
+            ))
         )}
       </div>
     </div>

--- a/examples/column-ordering/src/App.js
+++ b/examples/column-ordering/src/App.js
@@ -82,7 +82,7 @@ function Table({ columns, data }) {
         <tbody {...getTableBodyProps()}>
           {rows.slice(0, 10).map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map((cell, i) => {
                     return (
@@ -90,7 +90,7 @@ function Table({ columns, data }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/column-resizing/src/App.js
+++ b/examples/column-resizing/src/App.js
@@ -104,7 +104,7 @@ function Table({ columns, data }) {
       <div {...getTableBodyProps()}>
         {rows.map(
           (row, i) =>
-            prepareRow(row) || (
+            (prepareRow(row), (
               <div {...row.getRowProps()} className="tr">
                 {row.cells.map(cell => {
                   return (
@@ -114,7 +114,7 @@ function Table({ columns, data }) {
                   )
                 })}
               </div>
-            )
+            ))
         )}
       </div>
     </div>

--- a/examples/editable-data/src/App.js
+++ b/examples/editable-data/src/App.js
@@ -128,7 +128,7 @@ function Table({ columns, data, updateMyData, disablePageResetOnDataChange }) {
         <tbody {...getTableBodyProps()}>
           {page.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -136,7 +136,7 @@ function Table({ columns, data, updateMyData, disablePageResetOnDataChange }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/expanding/src/App.js
+++ b/examples/expanding/src/App.js
@@ -64,7 +64,7 @@ function Table({ columns: userColumns, data }) {
         <tbody {...getTableBodyProps()}>
           {rows.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -72,7 +72,7 @@ function Table({ columns: userColumns, data }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/filtering/src/App.js
+++ b/examples/filtering/src/App.js
@@ -255,7 +255,7 @@ function Table({ columns, data }) {
         <tbody {...getTableBodyProps()}>
           {firstPageRows.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -263,7 +263,7 @@ function Table({ columns, data }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/grouping/src/App.js
+++ b/examples/grouping/src/App.js
@@ -81,7 +81,7 @@ function Table({ columns, data }) {
         <tbody {...getTableBodyProps()}>
           {firstPageRows.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -120,7 +120,7 @@ function Table({ columns, data }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/kitchen-sink-controlled/src/App.js
+++ b/examples/kitchen-sink-controlled/src/App.js
@@ -352,7 +352,7 @@ function Table({ columns, data, updateMyData, disablePageResetOnDataChange }) {
         <tbody {...getTableBodyProps()}>
           {page.map(
             row =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -378,7 +378,7 @@ function Table({ columns, data, updateMyData, disablePageResetOnDataChange }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/kitchen-sink/src/App.js
+++ b/examples/kitchen-sink/src/App.js
@@ -352,7 +352,7 @@ function Table({ columns, data, updateMyData, disablePageResetOnDataChange }) {
         <tbody {...getTableBodyProps()}>
           {page.map(
             row =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -378,7 +378,7 @@ function Table({ columns, data, updateMyData, disablePageResetOnDataChange }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/material-UI-components/src/App.js
+++ b/examples/material-UI-components/src/App.js
@@ -41,7 +41,7 @@ function Table({ columns, data }) {
       <TableBody>
         {rows.map(
           (row, i) =>
-            prepareRow(row) || (
+            (prepareRow(row), (
               <TableRow {...row.getRowProps()}>
                 {row.cells.map(cell => {
                   return (
@@ -51,7 +51,7 @@ function Table({ columns, data }) {
                   )
                 })}
               </TableRow>
-            )
+            ))
         )}
       </TableBody>
     </MaUTable>

--- a/examples/pagination-controlled/src/App.js
+++ b/examples/pagination-controlled/src/App.js
@@ -117,7 +117,7 @@ function Table({
         <tbody {...getTableBodyProps()}>
           {page.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -125,7 +125,7 @@ function Table({
                     );
                   })}
                 </tr>
-              )
+              ))
           )}
           <tr>
             {loading ? (

--- a/examples/pagination/src/App.js
+++ b/examples/pagination/src/App.js
@@ -97,7 +97,7 @@ function Table({ columns, data }) {
         <tbody {...getTableBodyProps()}>
           {page.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -105,7 +105,7 @@ function Table({ columns, data }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/row-selection/src/App.js
+++ b/examples/row-selection/src/App.js
@@ -67,7 +67,7 @@ function Table({ columns, data }) {
         <tbody {...getTableBodyProps()}>
           {rows.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -75,7 +75,7 @@ function Table({ columns, data }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/sorting/README.md
+++ b/examples/sorting/README.md
@@ -46,13 +46,13 @@ function MyTable() {
       <tbody {...getTableBodyProps()}>
         {rows.map(
           (row, i) =>
-            prepareRow(row) || (
+            (prepareRow(row), (
               <tr {...row.getRowProps()}>
                 {row.cells.map(cell => {
                   return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
                 })}
               </tr>
-            )
+            ))
         )}
       </tbody>
     </table>

--- a/examples/sorting/src/App.js
+++ b/examples/sorting/src/App.js
@@ -79,7 +79,7 @@ function Table({ columns, data }) {
         <tbody {...getTableBodyProps()}>
           {firstPageRows.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 <tr {...row.getRowProps()}>
                   {row.cells.map(cell => {
                     return (
@@ -87,7 +87,7 @@ function Table({ columns, data }) {
                     )
                   })}
                 </tr>
-              )
+              ))
           )}
         </tbody>
       </table>

--- a/examples/sub-components/src/App.js
+++ b/examples/sub-components/src/App.js
@@ -72,7 +72,7 @@ function Table({ columns: userColumns, data, renderRowSubComponent }) {
         <tbody {...getTableBodyProps()}>
           {rows.map(
             (row, i) =>
-              prepareRow(row) || (
+              (prepareRow(row), (
                 // Use a React.Fragment here so the table markup is still valid
                 <>
                   <tr {...row.getRowProps()}>
@@ -101,7 +101,7 @@ function Table({ columns: userColumns, data, renderRowSubComponent }) {
                     </tr>
                   ) : null}
                 </>
-              )
+              ))
           )}
         </tbody>
       </table>


### PR DESCRIPTION
This PR would allow developers using typescript to copy/paste the examples without seeing a compiler error.

Use of void in a control flow construct - i.e. `() => void || nextFunction()` - is disallowed by typescript see: [issue](https://github.com/microsoft/TypeScript/issues/26262). As the project is in `js`, no big deal. But as a satisfied consumer of the `index.d.ts` file I figured I'd extend the thanks if you have interest in changing the syntax in the examples.

Thanks!