### PR TITLE
Adding useColumnVisibility - for column visibility toggling 

### DIFF
--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -8,8 +8,7 @@ import {
   flexRender,
   decorateColumnTree,
   makeHeaderGroups,
-  flattenBy,
-  determineHeaderVisibility,
+  flattenBy
 } from '../utils'
 
 const propTypes = {
@@ -229,9 +228,6 @@ export const useTable = (props, ...plugins) => {
 
   instanceRef.current.rows = rows
   instanceRef.current.flatRows = flatRows
-
-  // Determine column visibility
-  determineHeaderVisibility(instanceRef.current)
 
   // Provide a flat header list for utilities
   instanceRef.current.flatHeaders = headerGroups.reduce(

--- a/src/plugin-hooks/useColumnVisibility.js
+++ b/src/plugin-hooks/useColumnVisibility.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { defaultState } from '../../react-table/hooks/useTable';
+import { addActions, actions } from '../../react-table/actions';
+import { determineHeaderVisibility } from '../../react-table/utils';
+
+addActions('setColumnVisibility');
+
+defaultState.hiddenColumns = [];
+
+const propTypes = {};
+
+export const useColumnVisibility = (hooks) => {
+  hooks.useBeforeDimensions.push(useBeforeDimensions);
+};
+
+useColumnVisibility.pluginName = 'useColumnVisibility';
+
+function useBeforeDimensions(instance) {
+  PropTypes.checkPropTypes(propTypes, instance, 'property', 'useColumnVisibility');
+
+  const {
+    flatHeaders,
+    state: { hiddenColumns },
+    setState
+  } = instance;
+
+  const setColumnVisibility = React.useCallback(
+    (updater) => {
+      return setState((old) => {
+        return {
+          ...old,
+          columnOrder: [...old.columnOrder], // FixMe: hack
+          hiddenColumns: typeof updater === 'function' ? updater(old.hiddenColumns) : updater
+        };
+      }, actions.setColumnVisibility);
+    },
+    [setState]
+  );
+
+  flatHeaders.forEach((column) => {
+    column.show = !hiddenColumns.includes(column.id);
+
+    column.setColumnVisibility = (show) => {
+      column.show = show;
+      const newhiddenColumns = new Set(hiddenColumns);
+
+      if (show) {
+        newhiddenColumns.delete(column.id);
+      } else {
+        newhiddenColumns.add(column.id);
+      }
+
+      setColumnVisibility(Array.from(newhiddenColumns));
+    };
+
+    column.toggleColumnVisibility = () => {
+      column.setColumnVisibility(!column.show);
+    };
+  });
+
+  determineHeaderVisibility(instance);
+
+  return {
+    ...instance,
+    setColumnVisibility
+  };
+}

--- a/src/plugin-hooks/useColumnVisibility.js
+++ b/src/plugin-hooks/useColumnVisibility.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { defaultState } from '../../react-table/hooks/useTable';
-import { addActions, actions } from '../../react-table/actions';
-import { determineHeaderVisibility } from '../../react-table/utils';
+import { defaultState } from '..//hooks/useTable';
+import { addActions, actions } from '../actions';
+import { determineHeaderVisibility } from '../utils';
 
 addActions('setColumnVisibility');
 
@@ -12,6 +12,9 @@ defaultState.hiddenColumns = [];
 const propTypes = {};
 
 export const useColumnVisibility = (hooks) => {
+  hooks.columnsBeforeHeaderGroupsDeps.push((deps, instance) => {
+    return [...deps, instance.state.hiddenColumns];
+  });
   hooks.useBeforeDimensions.push(useBeforeDimensions);
 };
 
@@ -31,7 +34,6 @@ function useBeforeDimensions(instance) {
       return setState((old) => {
         return {
           ...old,
-          columnOrder: [...old.columnOrder], // FixMe: hack
           hiddenColumns: typeof updater === 'function' ? updater(old.hiddenColumns) : updater
         };
       }, actions.setColumnVisibility);

--- a/src/plugin-hooks/useColumnVisibility.js
+++ b/src/plugin-hooks/useColumnVisibility.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { defaultState } from '..//hooks/useTable';
+import { defaultState } from '../hooks/useTable';
 import { addActions, actions } from '../actions';
 import { determineHeaderVisibility } from '../utils';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,6 @@ import React from 'react'
 
 export const defaultColumn = {
   Cell: ({ cell: { value = '' } }) => String(value),
-  show: true,
   width: 150,
   minWidth: 0,
   maxWidth: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
This provides us the capability to have 
`toggleColumnVisibility` - to toggle column visibility, available at column level
`setColumnVisibility` - set column visibility, available at column level
`setColumnVisibility` - available at instance level, expects array of column ids which are to be hidden

Can enable lib user's to implement `show all`/`hide all` easily using above API.

As other hooks takes initial state, column level `show` flag will not be applicable anymore.


