### PR TITLE
Fix types of getRowID & getSubRows

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,8 @@ export type UseTableOptions<D extends object> = {
   ) => TableState<D>
   defaultColumn: Partial<Column<D>>
   initialRowStateKey: IdType<D>
-  getSubRows: (row: Row<D>, relativeIndex: number) => Array<Row<D>>
-  getRowID: (row: Row<D>, relativeIndex: number) => string
+  getSubRows: (originalRow: D, relativeIndex: number) => Array<D>
+  getRowID: (originalRow: D, relativeIndex: number) => IdType<D>
   debug: boolean
 }>
 
@@ -210,7 +210,6 @@ export namespace useExpanded {
 }
 
 export type UseExpandedOptions<D extends object> = Partial<{
-  getSubRows: (row: Row<D>, relativeIndex: number) => Array<Row<D>>
   manualExpandedKey: IdType<D>
   paginateExpandedRows: boolean
   getResetExpandedDeps: (i: TableInstance) => Array<any>


### PR DESCRIPTION
Fixes #1628 

- These 2 methods receive the original row object (`<D>`)
- getSubRows returns an array of original rows (`Array<D>`)
- Changed return type of getRowID to match type of Row.path (`Array<IdType<D>>`)

- **_[Please confirm]_** Removed getSubRows from UseExpandedOptions as it doesn't appear to be used.