### PR TITLE
Types: getGroupByToggleProps was lost

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -356,9 +356,6 @@ export interface UseGroupByColumnProps<D extends object> {
   isGrouped: boolean
   groupedIndex: number
   toggleGroupBy: () => void
-}
-
-export interface UseGroupByHeaderProps<D extends object> {
   getGroupByToggleProps: (props?: object) => object
 }
 


### PR DESCRIPTION
* There it was, on an unused UseGroupByHeaderProps interface, while it should have been on UseGroupByColumnProps.