### PR TITLE
[Fix] defaultGetResetPageDeps should listen to data, not rows

### DIFF
--- a/src/plugin-hooks/usePagination.js
+++ b/src/plugin-hooks/usePagination.js
@@ -17,10 +17,10 @@ export const usePagination = hooks => {
 usePagination.pluginName = 'usePagination'
 
 const defaultGetResetPageDeps = ({
-  rows,
+  data,
   manualPagination,
   state: { filters, groupBy, sortBy },
-}) => [manualPagination ? null : rows, filters, groupBy, sortBy]
+}) => [manualPagination ? null : data, filters, groupBy, sortBy]
 
 function useMain(instance) {
   const {


### PR DESCRIPTION
Fixes #1657 

[Discussion at spectrum](https://spectrum.chat/react-table/general/v7-maximum-update-depth-exceeded-usegroupby-useexpanded-with-usepagination~2c25e2b8-7a61-4c32-84b3-87db458701c2)

Thanks to @iamjon for identifying usePagination was the culprit.
I then checked the last changes made to it, and noticed it was previously listening to data and now it listened to rows (which I believe is a new reference on each render), causing infinite loop on one of its effects.

I tested this change on my project and everything seems ok now.