### PR TITLE
Remove tooltip if columnDisableSortBy

### DIFF
--- a/src/plugin-hooks/tests/__snapshots__/useSortBy.test.js.snap
+++ b/src/plugin-hooks/tests/__snapshots__/useSortBy.test.js.snap
@@ -5,7 +5,7 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -22,11 +22,13 @@
+@@ -20,11 +20,13 @@
             colspan="1"
             style="cursor: pointer;"
             title="Toggle SortBy"
@@ -20,7 +20,7 @@ Snapshot Diff:
             colspan="1"
             style="cursor: pointer;"
             title="Toggle SortBy"
-@@ -69,66 +71,66 @@
+@@ -67,66 +69,66 @@
         </tr>
       </thead>
       <tbody>
@@ -112,7 +112,7 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -23,11 +23,11 @@
+@@ -21,11 +21,11 @@
             style="cursor: pointer;"
             title="Toggle SortBy"
           >
@@ -125,7 +125,7 @@ Snapshot Diff:
           <th
             colspan="1"
             style="cursor: pointer;"
-@@ -71,26 +71,26 @@
+@@ -69,26 +69,26 @@
         </tr>
       </thead>
       <tbody>
@@ -158,7 +158,7 @@ Snapshot Diff:
         <tr>
           <td>
             firstName: joe
-@@ -111,26 +111,26 @@
+@@ -109,26 +109,26 @@
             progress: 10
           </td>
         </tr>

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -238,7 +238,7 @@ function useInstance(instance) {
           style: {
             cursor: canSort ? 'pointer' : undefined,
           },
-          title: 'Toggle SortBy',
+          title: canSort ? 'Toggle SortBy' : undefined,
         },
         applyPropHooks(
           instanceRef.current.hooks.getSortByToggleProps,


### PR DESCRIPTION
When sorting is disabled there is no onClick on this column, so we also did not need the tooltip.