### PR TITLE
fix: fix crash in useSortBy resetSortBy action

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 96773,
-    "minified": 46756,
-    "gzipped": 12302
+    "bundled": 96781,
+    "minified": 46762,
+    "gzipped": 12304
   },
   "dist/index.es.js": {
-    "bundled": 96208,
-    "minified": 46264,
-    "gzipped": 12186,
+    "bundled": 96216,
+    "minified": 46270,
+    "gzipped": 12188,
     "treeshaked": {
       "rollup": {
         "code": 78,

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -30,7 +30,7 @@ reducerHandlers[pluginName] = (state, action) => {
   if (action.type === actions.resetSortBy) {
     return {
       ...state,
-      sortBy: {},
+      sortBy: [],
     }
   }
 


### PR DESCRIPTION
`resetSortBy` changes the `state.sortBy` property from an array to an object, causing a crash at https://github.com/tannerlinsley/react-table/blob/master/src/plugin-hooks/useSortBy.js#L252 when my project reloads via HMR.