### PR TITLE
[getResetDeps] fix instance param lag

### DIFF
--- a/src/plugin-hooks/useFilters.js
+++ b/src/plugin-hooks/useFilters.js
@@ -132,15 +132,6 @@ function useInstance(instance) {
   const preFilteredRows = rows
   const preFilteredFlatRows = flatRows
 
-  // Bypass any effects from firing when this changes
-  const isMountedRef = React.useRef()
-  safeUseLayoutEffect(() => {
-    if (isMountedRef.current) {
-      dispatch({ type: actions.resetFilters })
-    }
-    isMountedRef.current = true
-  }, [dispatch, ...(getResetFiltersDeps ? getResetFiltersDeps(instance) : [])])
-
   const setFilter = (columnId, filterValue) => {
     dispatch({ type: actions.setFilter, columnId, filterValue })
   }
@@ -288,6 +279,26 @@ function useInstance(instance) {
       column.filteredRows = filteredRows
     })
   }, [filteredRows, filters, flatColumns])
+
+  // Bypass any effects from firing when this changes
+  const isMountedRef = React.useRef()
+  safeUseLayoutEffect(() => {
+    if (isMountedRef.current) {
+      dispatch({ type: actions.resetFilters })
+    }
+    isMountedRef.current = true
+  }, [
+    dispatch,
+    ...(getResetFiltersDeps
+      ? getResetFiltersDeps({
+          ...instance,
+          preFilteredRows,
+          preFilteredFlatRows,
+          rows: filteredRows,
+          flatRows: filteredFlatRows,
+        })
+      : []),
+  ])
 
   return {
     ...instance,

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -177,15 +177,6 @@ function useInstance(instance) {
   // Add custom hooks
   hooks.getSortByToggleProps = []
 
-  // Bypass any effects from firing when this changes
-  const isMountedRef = React.useRef()
-  safeUseLayoutEffect(() => {
-    if (isMountedRef.current) {
-      dispatch({ type: actions.resetSortBy })
-    }
-    isMountedRef.current = true
-  }, [dispatch, ...(getResetSortByDeps ? getResetSortByDeps(instance) : [])])
-
   // Updates sorting based on a columnId, desc flag and multi flag
   const toggleSortBy = (columnId, desc, multi) => {
     dispatch({ type: actions.toggleSortBy, columnId, desc, multi })
@@ -343,6 +334,25 @@ function useInstance(instance) {
     flatColumns,
     orderByFn,
     userSortTypes,
+  ])
+
+  // Bypass any effects from firing when this changes
+  const isMountedRef = React.useRef()
+  safeUseLayoutEffect(() => {
+    if (isMountedRef.current) {
+      dispatch({ type: actions.resetSortBy })
+    }
+    isMountedRef.current = true
+  }, [
+    dispatch,
+    ...(getResetSortByDeps
+      ? getResetSortByDeps({
+          ...instance,
+          toggleSortBy,
+          rows: sortedRows,
+          preSortedRows: rows,
+        })
+      : []),
   ])
 
   return {


### PR DESCRIPTION
I want to use the getResetFiltersDeps to detect the state for resetting the filters. I want to reset the filters, when the user deletes all filtered items. So I must check the instance rows length to be 0. But the instance.row param on the getResetFiltersDeps function lags one render behinde. To fix this i moved the effect function at the end of the useFilter function and pass the updated row into the instance param.
I tought that this fix could by applyed to other use functions (sort, pagination, etc.)