### PR TITLE
docs(docs/api/readme.md): fix to useTable link that was giving 404

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -2,12 +2,12 @@
   "dist/index.js": {
     "bundled": 102847,
     "minified": 50399,
-    "gzipped": 12909
+    "gzipped": 12905
   },
   "dist/index.es.js": {
     "bundled": 101791,
     "minified": 49456,
-    "gzipped": 12726,
+    "gzipped": 12722,
     "treeshaked": {
       "rollup": {
         "code": 78,

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,7 +5,7 @@ React Table uses React Hooks both internally and externally for almost all of it
 React Table is essentially a compatible collection of **custom React hooks**:
 
 - The primary React Table hook
-  - [`useTable`](./usetable.md)
+  - [`useTable`](./useTable.md)
 - Plugin Hooks
   - Core Plugin Hooks
     - [`useGroupBy`](./useGroupBy.md)


### PR DESCRIPTION
In the /docs/api/README.md the useTable link was linking to the file ./usetable.md that doesn't
exist, now it links to ./useTable