### PR TITLE
Fix row.toggleExpanded(bool)

### DIFF
--- a/src/plugin-hooks/useExpanded.js
+++ b/src/plugin-hooks/useExpanded.js
@@ -42,7 +42,7 @@ function reducer(state, action) {
     const { path, expanded } = action
     const key = path.join('.')
     const exists = state.expanded.includes(key)
-    const shouldExist = typeof set !== 'undefined' ? expanded : !exists
+    const shouldExist = typeof expanded !== 'undefined' ? expanded : !exists
     let newExpanded = new Set(state.expanded)
 
     if (!exists && shouldExist) {


### PR DESCRIPTION
The wrong variable was being checked against `undefined`, so the row was always being toggled, rather than taking the parameter into account.