### PR TITLE
fix: render components should include memo/forwardRef

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -237,8 +237,20 @@ function isFunctionComponent(component) {
   return typeof component === 'function'
 }
 
+function isExoticComponent(component) {
+  return (
+    typeof component === 'object' &&
+    typeof component.$$typeof === 'symbol' &&
+    ['react.memo', 'react.forward_ref'].includes(component.$$typeof.description)
+  )
+}
+
 function isReactComponent(component) {
-  return isClassComponent(component) || isFunctionComponent(component)
+  return (
+    isClassComponent(component) ||
+    isFunctionComponent(component) ||
+    isExoticComponent(component)
+  )
 }
 
 export function isFunction(a) {


### PR DESCRIPTION
User should be able to pass render components wrapped by `React.memo` and `React.forwardRef` in column definitions.
Though `React.forwardRef` is not so valid here since the render function will only pass the props to the render, I think it should be safely included.

See the bugged example: https://codesandbox.io/s/fervent-night-6v86g, which should be fixed by this pr.