### PR TITLE
Update to use React.Fragment spread with row props

### DIFF
--- a/examples/sub-components/src/App.js
+++ b/examples/sub-components/src/App.js
@@ -74,8 +74,8 @@ function Table({ columns: userColumns, data, renderRowSubComponent }) {
             prepareRow(row)
             return (
               // Use a React.Fragment here so the table markup is still valid
-              <>
-                <tr {...row.getRowProps()}>
+              <React.Fragment {...row.getRowProps()}>
+                <tr>
                   {row.cells.map(cell => {
                     return (
                       <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
@@ -100,7 +100,7 @@ function Table({ columns: userColumns, data, renderRowSubComponent }) {
                     </td>
                   </tr>
                 ) : null}
-              </>
+              </React.Fragment>
             )
           })}
         </tbody>


### PR DESCRIPTION
Addresses issue #1780 , fixing the React console warning for the "Sub-Components" regarding the lack of unique key for each child in list.

## Changes

Replaces `<>` with `<React.Fragment>`, spreading the row props onto the fragment.