### PR TITLE
Fix groupBy removed columns (#1776)

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "dist\\index.js": {
-    "bundled": 105386,
-    "minified": 49565,
-    "gzipped": 13008
+    "bundled": 104977,
+    "minified": 48560,
+    "gzipped": 13057
   },
   "dist\\index.es.js": {
-    "bundled": 104543,
-    "minified": 48815,
-    "gzipped": 12856,
+    "bundled": 104090,
+    "minified": 47770,
+    "gzipped": 12900,
     "treeshaked": {
       "rollup": {
         "code": 80,
         "import_statements": 21
       },
       "webpack": {
-        "code": 8444
+        "code": 8227
       }
     }
   }

--- a/src/plugin-hooks/tests/useGroupBy.test.js
+++ b/src/plugin-hooks/tests/useGroupBy.test.js
@@ -64,6 +64,9 @@ function Table({ columns, data }) {
       columns,
       data,
       defaultColumn,
+      initialState: {
+        groupBy: ["Column Doesn't Exist"],
+      },
     },
     useGroupBy,
     useExpanded


### PR DESCRIPTION
Turns out it's super easy to simulate the error by setting the initial state with a group-by column that doesn't exist, so I just modified the existing test to contain that.