### PR TITLE
fix Manual Pagination - useAsyncDebounce fn not a function

### DIFF
--- a/src/publicUtils.js
+++ b/src/publicUtils.js
@@ -195,7 +195,7 @@ export function useAsyncDebounce(defaultFn, defaultWait = 0) {
 
   const debounce = React.useCallback(
     async (
-      fn = debounceRef.current.defaultFn,
+      state = debounceRef.current.defaultFn,
       wait = debounceRef.current.defaultWait
     ) => {
       if (!debounceRef.current.promise) {
@@ -212,7 +212,9 @@ export function useAsyncDebounce(defaultFn, defaultWait = 0) {
       debounceRef.current.timeout = setTimeout(async () => {
         delete debounceRef.current.timeout
         try {
-          debounceRef.current.resolve(await fn())
+          debounceRef.current.resolve(
+            await debounceRef.current.defaultFn(state)
+          )
         } catch (err) {
           debounceRef.current.reject(err)
         } finally {


### PR DESCRIPTION
this pr fixes the console error that shown when using useAsyncDebounce function and causing table break, related issue: https://github.com/tannerlinsley/react-table/issues/1794