### PR TITLE
fix(usefilters): fix userFilterTypes alias in setFilter action

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 113159,
-    "minified": 52747,
-    "gzipped": 13786
+    "bundled": 113233,
+    "minified": 52524,
+    "gzipped": 13836
   },
   "dist/index.es.js": {
-    "bundled": 111809,
-    "minified": 51501,
-    "gzipped": 13598,
+    "bundled": 112296,
+    "minified": 51688,
+    "gzipped": 13670,
     "treeshaked": {
       "rollup": {
         "code": 80,

--- a/src/plugin-hooks/useFilters.js
+++ b/src/plugin-hooks/useFilters.js
@@ -40,7 +40,7 @@ function reducer(state, action, previousState, instance) {
 
   if (action.type === actions.setFilter) {
     const { columnId, filterValue } = action
-    const { flatColumns, userFilterTypes } = instance
+    const { flatColumns, filterTypes: userFilterTypes } = instance
 
     const column = flatColumns.find(d => d.id === columnId)
 


### PR DESCRIPTION
Fix to correctly alias filterTypes to userFilterTypes in set filter action, so that the filter
autoremove method is called correctly

fix #1831