### PR TITLE
docs: link to the original blog post instead of medium

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,7 +2,7 @@
 
 ## React Table is a "headless" UI library
 
-React Table is a headless utility, which means out of the box, it doesn't render or supply any actual UI elements. You are in charge of utilizing the state and callbacks of the hooks provided by this library to render your own table markup. [Read this article to understand why React Table is built this way](https://medium.com/merrickchristensen/headless-user-interface-components-565b0c0f2e18). If you don't want to, then here's a quick rundown anyway:
+React Table is a headless utility, which means out of the box, it doesn't render or supply any actual UI elements. You are in charge of utilizing the state and callbacks of the hooks provided by this library to render your own table markup. [Read this article to understand why React Table is built this way](https://www.merrickchristensen.com/articles/headless-user-interface-components/). If you don't want to, then here's a quick rundown anyway:
 
 - Separation of Concerns - Not that superficial kind you read about all the time. The real kind. React Table as a library honestly has no business being in charge of your UI. The look, feel, and overall experience of your table is what makes your app or product great. The less React Table gets in the way of that, the better!
 - Maintenance - By removing the massive (and seemingly endless) API surface area required to support every UI use-case, React Table can remain small, easy-to-use and simple to update/maintain.


### PR DESCRIPTION
This is a very small and opinionated suggestion regarding the «Concept» section of the docs.

Just link to the original blog post and ditch Medium, especially given the fact that you already have it online somewhere else. I really don't care about their business model, but in terms of UX/UI Medium is an abomination. I tried to read the thing on my mobile on a train ride earlier today. Ugh.
Then I found the link at the top (I know, right) that points to the original post – much cleaner, no more fighting modals and whatever shitshow is going on over there – I mean, just *readable* fcs. 

I might be unaware of some advantages you see by promoting Medium over your own, imho much better approach. If there are any, just don't mind me. 

Thanks for the project and have a nice weekend!

Regards
Lukas

Edit: Just realised, it's probably not you (the lib author) who wrote the blog post. Still, I'd rather have the link point to the original thing than Medium. 