### PR TITLE
Fix useFlexLayout table min-width

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 113233,
-    "minified": 52524,
-    "gzipped": 13836
+    "bundled": 113228,
+    "minified": 52519,
+    "gzipped": 13842
   },
   "dist/index.es.js": {
-    "bundled": 112296,
-    "minified": 51688,
-    "gzipped": 13670,
+    "bundled": 112291,
+    "minified": 51683,
+    "gzipped": 13676,
     "treeshaked": {
       "rollup": {
         "code": 80,

--- a/examples/full-width-resizable-table/src/App.js
+++ b/examples/full-width-resizable-table/src/App.js
@@ -11,13 +11,12 @@ import makeData from './makeData'
 
 const Styles = styled.div`
   padding: 1rem;
+  ${'' /* These styles are suggested for the table fill all available space in its containing element */}
+  display: block;
+  ${'' /* These styles are required for a horizontaly scrollable table overflow */}
+  overflow: auto;
 
   .table {
-    ${'' /* These styles are suggested for the table fill all available space in its containing element */}
-    display: block;
-    ${'' /* These styles are required for a horizontaly scrollable table overflow */}
-    overflow: auto;
-
     border-spacing: 0;
     border: 1px solid black;
 
@@ -129,13 +128,7 @@ function Table({ columns, data }) {
     []
   )
 
-  const {
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    rows,
-    prepareRow,
-  } = useTable(
+  const { getTableProps, headerGroups, rows, prepareRow } = useTable(
     {
       columns,
       data,
@@ -205,8 +198,8 @@ function Table({ columns, data }) {
           </div>
         ))}
       </div>
-      <div {...getTableBodyProps()} className="tbody">
-        {rows.map((row, i) => {
+      <div className="tbody">
+        {rows.map(row => {
           prepareRow(row)
           return (
             <div {...row.getRowProps()} className="tr">

--- a/src/plugin-hooks/useFlexLayout.js
+++ b/src/plugin-hooks/useFlexLayout.js
@@ -1,5 +1,5 @@
 export function useFlexLayout(hooks) {
-  hooks.getTableBodyProps.push(getTableBodyProps)
+  hooks.getTableProps.push(getTableProps)
   hooks.getRowProps.push(getRowStyles)
   hooks.getHeaderGroupProps.push(getRowStyles)
   hooks.getHeaderProps.push(getHeaderProps)
@@ -8,7 +8,7 @@ export function useFlexLayout(hooks) {
 
 useFlexLayout.pluginName = 'useFlexLayout'
 
-const getTableBodyProps = (props, { instance }) => [
+const getTableProps = (props, { instance }) => [
   props,
   {
     style: {
@@ -33,7 +33,9 @@ const getHeaderProps = (props, { column }) => [
   {
     style: {
       boxSizing: 'border-box',
-      flex: column.totalFlexWidth ? `${column.totalFlexWidth} 0 auto` : undefined,
+      flex: column.totalFlexWidth
+        ? `${column.totalFlexWidth} 0 auto`
+        : undefined,
       minWidth: `${column.totalMinWidth}px`,
       width: `${column.totalWidth}px`,
     },


### PR DESCRIPTION
Current implementation of useFlexLayout has an issue where styles are not applied beyond the viewport. As a result, the header borders are not stretched to the entire width of the table in the screenshot below.
 
<img width="658" alt="Screen Shot 2020-01-13 at 4 23 24 PM" src="https://user-images.githubusercontent.com/6496667/72305612-2f19cb00-3629-11ea-88fd-7f9b1d5f27a8.png">

You can see this happening in the [full-width-resizable-table codesandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/full-width-resizable-table).

The cause is because the min-width is not set for the table. It is set for the body only which is why this issue doesn't affect the it. Fixed by moving the min-width style to getTableProps and removed the now-redundant style in getTableBodyProps.