### PR TITLE
Adds default value to filter

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 113233,
-    "minified": 52524,
-    "gzipped": 13836
+    "bundled": 113250,
+    "minified": 52535,
+    "gzipped": 13844
   },
   "dist/index.es.js": {
-    "bundled": 112296,
-    "minified": 51688,
-    "gzipped": 13670,
+    "bundled": 112313,
+    "minified": 51699,
+    "gzipped": 13675,
     "treeshaked": {
       "rollup": {
         "code": 80,

--- a/src/plugin-hooks/useFilters.js
+++ b/src/plugin-hooks/useFilters.js
@@ -90,7 +90,7 @@ function reducer(state, action, previousState, instance) {
   }
 
   if (action.type === actions.setAllFilters) {
-    const { filters } = action
+    const filters = action.filters || []
     const { flatColumns, filterTypes: userFilterTypes } = instance
 
     return {


### PR DESCRIPTION
In a production build of a private application I get an undefined error. This error is thrown from line 99 of the `useFilter` plugin. The `filters` variable is an empty string and `filter` is not a function. Hence the error.

I am having trouble identifying the root cause of this bug. It only occurs in my production minified application. My development build is fine. Worse, I cannot reproduce the issue using the example in this library. I will try to isolate the bug in the future but debugging in a production-minified file is hard. Defaulting `filters` to an array resolves the issue.

**tl;dr**: Please allow this default value so I don't have to fix my broken code.