### PR TITLE
Add `Column` data in `autoRemove` of Filters

### DIFF
--- a/src/plugin-hooks/useFilters.js
+++ b/src/plugin-hooks/useFilters.js
@@ -64,7 +64,7 @@ function reducer(state, action, previousState, instance) {
     )
 
     //
-    if (shouldAutoRemoveFilter(filterMethod.autoRemove, newFilter)) {
+    if (shouldAutoRemoveFilter(filterMethod.autoRemove, newFilter, column)) {
       return {
         ...state,
         filters: state.filters.filter(d => d.id !== columnId),
@@ -104,7 +104,7 @@ function reducer(state, action, previousState, instance) {
           filterTypes
         )
 
-        if (shouldAutoRemoveFilter(filterMethod.autoRemove, filter.value)) {
+        if (shouldAutoRemoveFilter(filterMethod.autoRemove, filter.value, column)) {
           return false
         }
         return true

--- a/src/utils.js
+++ b/src/utils.js
@@ -276,8 +276,8 @@ export function getFilterMethod(filter, userFilterTypes, filterTypes) {
   )
 }
 
-export function shouldAutoRemoveFilter(autoRemove, value) {
-  return autoRemove ? autoRemove(value) : typeof value === 'undefined'
+export function shouldAutoRemoveFilter(autoRemove, value, column) {
+  return autoRemove ? autoRemove(value, column) : typeof value === 'undefined'
 }
 
 //


### PR DESCRIPTION
To auto remove `filters` using `autoRemove` fn on `ColumnFilter`, there may be some use-cases which require `Column` metadata to be available for making decisions. 