### PR TITLE
Fix code sandbox for kitchen sink

### DIFF
--- a/examples/kitchen-sink-controlled/src/App.js
+++ b/examples/kitchen-sink-controlled/src/App.js
@@ -301,8 +301,8 @@ function Table({ columns, data, updateMyData, skipPageReset }) {
       // when we edit the data, undefined means using the default
       autoResetPage: !skipPageReset,
     },
-    useGroupBy,
     useFilters,
+    useGroupBy,
     useSortBy,
     useExpanded,
     usePagination,


### PR DESCRIPTION
There's an error on this page that says `useGroupBy` must come after `useFilters`