### PR TITLE
useRowSelect: remove redundant checks

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 130976,
-    "minified": 61378,
-    "gzipped": 15745
+    "bundled": 130947,
+    "minified": 61370,
+    "gzipped": 15740
   },
   "dist/index.es.js": {
-    "bundled": 130034,
-    "minified": 60537,
-    "gzipped": 15571,
+    "bundled": 130005,
+    "minified": 60529,
+    "gzipped": 15565,
     "treeshaked": {
       "rollup": {
         "code": 80,

--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -138,7 +138,7 @@ function reducer(state, action, previousState, instance) {
       if (!row.isGrouped) {
         if (shouldExist) {
           newSelectedRowIds[id] = true
-        } else if (!shouldExist) {
+        } else {
           delete newSelectedRowIds[id]
         }
       }

--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -136,9 +136,9 @@ function reducer(state, action, previousState, instance) {
       const row = rowsById[id]
 
       if (!row.isGrouped) {
-        if (!isSelected && shouldExist) {
+        if (shouldExist) {
           newSelectedRowIds[id] = true
-        } else if (isSelected && !shouldExist) {
+        } else if (!shouldExist) {
           delete newSelectedRowIds[id]
         }
       }


### PR DESCRIPTION
The `shouldExist` is enough to check if we should add or remove a row from the list of selected rows: 

https://github.com/tannerlinsley/react-table/blob/10a5a9226027149004ffed7cf3d3dd26b41afbac/src/plugin-hooks/useRowSelect.js#L125-L127

And for the case when the value is the same as before, we already return from the function: 

https://github.com/tannerlinsley/react-table/blob/10a5a9226027149004ffed7cf3d3dd26b41afbac/src/plugin-hooks/useRowSelect.js#L129-L131

I had an issue where for some reasons my table had `undefined` for the `isSelected` there, but couldn't reproduce it on CodeSandbox. This issue seemed to impact only these conditions, making selected rows not uncheckable, removing this unnecessary check fixes it for me.

If someone knows why the `isSelected` can be `undefined` in the first place — I couldn't find this out easily — maybe it would be worth investigating, but even then I think those checks are redundant.