### PR TITLE
useTable: Fixes memoizing of headerGroups

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.js": {
-    "bundled": 130976,
-    "minified": 61378,
-    "gzipped": 15745
+    "bundled": 131106,
+    "minified": 61407,
+    "gzipped": 15752
   },
   "dist/index.es.js": {
-    "bundled": 130034,
-    "minified": 60537,
-    "gzipped": 15571,
+    "bundled": 130164,
+    "minified": 60566,
+    "gzipped": 15578,
     "treeshaked": {
       "rollup": {
         "code": 80,

--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -380,40 +380,42 @@ export const useTable = (props, ...plugins) => {
     }
   )
 
-  getInstance().headerGroups = getInstance().headerGroups.filter(
-    (headerGroup, i) => {
-      // Filter out any headers and headerGroups that don't have visible columns
-      headerGroup.headers = headerGroup.headers.filter(column => {
-        const recurse = headers =>
-          headers.filter(column => {
-            if (column.headers) {
-              return recurse(column.headers)
-            }
-            return column.isVisible
-          }).length
-        if (column.headers) {
-          return recurse(column.headers)
+  getInstance().headerGroups = React.useMemo(
+    () =>
+      headerGroups.filter((headerGroup, i) => {
+        // Filter out any headers and headerGroups that don't have visible columns
+        headerGroup.headers = headerGroup.headers.filter(column => {
+          const recurse = headers =>
+            headers.filter(column => {
+              if (column.headers) {
+                return recurse(column.headers)
+              }
+              return column.isVisible
+            }).length
+          if (column.headers) {
+            return recurse(column.headers)
+          }
+          return column.isVisible
+        })
+
+        // Give headerGroups getRowProps
+        if (headerGroup.headers.length) {
+          headerGroup.getHeaderGroupProps = makePropGetter(
+            getHooks().getHeaderGroupProps,
+            { instance: getInstance(), headerGroup, index: i }
+          )
+
+          headerGroup.getFooterGroupProps = makePropGetter(
+            getHooks().getFooterGroupProps,
+            { instance: getInstance(), headerGroup, index: i }
+          )
+
+          return true
         }
-        return column.isVisible
-      })
 
-      // Give headerGroups getRowProps
-      if (headerGroup.headers.length) {
-        headerGroup.getHeaderGroupProps = makePropGetter(
-          getHooks().getHeaderGroupProps,
-          { instance: getInstance(), headerGroup, index: i }
-        )
-
-        headerGroup.getFooterGroupProps = makePropGetter(
-          getHooks().getFooterGroupProps,
-          { instance: getInstance(), headerGroup, index: i }
-        )
-
-        return true
-      }
-
-      return false
-    }
+        return false
+      }),
+    [headerGroups, getInstance, getHooks]
   )
 
   getInstance().footerGroups = [...getInstance().headerGroups].reverse()


### PR DESCRIPTION
When the headerGroups were defined at first, they were memoized and then attached to `getInstance()`, but later `getInstance().headerGroups` was redefined using a filter, removing the memoizing.

That PR fixes it by properly memoizing the new filtered `headerGroups`.

[Diff without whitespace changes](https://github.com/tannerlinsley/react-table/pull/1920/files?utf8=%E2%9C%93&diff=split&w=1)