### PR TITLE
Update useRowSelect.md

### DIFF
--- a/docs/api/useRowSelect.md
+++ b/docs/api/useRowSelect.md
@@ -58,6 +58,13 @@ The following additional properties are available on every **prepared** `row` ob
 - `toggleRowSelected: Function(?set)`
   - Use this function to toggle this row's selected state.
   - Optionally pass `true` or `false` to set it to that state
+- `getToggleRowSelectedProps: Function(props) => props`
+  - Use this function to get the props needed for a **select row checkbox**.
+  - Props:
+    - `onChange: Function()`
+    - `style.cursor: 'pointer'`
+    - `checked: Bool`
+    - `title: 'Toggle Row Selected'`
 
 ### Example
 


### PR DESCRIPTION
Missing documentation for `getToggleRowSelectedProps`, used on the [example](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/row-selection).

The `indeterminate` field is not documented at all, and I wonder what's the difference to the `checked` field.

PS: just a quick shoutout: I'm absolutely loving the design of `react-table`. sooo flexible! thanks for the great work @tannerlinsley 