### PR TITLE
Fix combining the new visible columns with all

### DIFF
--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -237,11 +237,11 @@ export const useTable = (props, ...plugins) => {
     ]
   )
 
-  // Combine new visible columns with all columns (dedupe prefers later columns)
+  // Combine new visible columns with all columns
   allColumns = React.useMemo(() => {
-    const columns = [...allColumns]
+    const columns = [...visibleColumns]
 
-    visibleColumns.forEach(column => {
+    allColumns.forEach(column => {
       if (!columns.find(d => d.id === column.id)) {
         columns.push(column)
       }


### PR DESCRIPTION
One of the more recent fixes (https://github.com/tannerlinsley/react-table/commit/42b41d1260fab3c6635b071ca984dce253bf23ab#diff-58070e993396b86d9cd977598221d49eR241-R251) broke some of the stuff with the visibleColumns.

Basically, previously after all the `vislbleColumns` hooks they were retroactively added back to `allColumns`. The new way without deduping is mistakenly prioritizes columns from the `allColumns`, not overwriting them with those from the `visibleColumns`.

In this PR I just changed it so the new `allColumns` would be `visibleColumns` first and then it only those columns not present in the `visibleColumns` would be pushed, which seems like what was intended.

I've tested this fix on my project (which broke after upgrading to the 7.0.0 release) with a yarn's `portal:`, and it worked.