### PR TITLE
Add dependency on Scarf for installation analytics

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,15 @@
 # Installation
 
-Install React Table as a dependency using `npm` or `yarn`
+Install React Table as a dependency using `npm` or `yarn`. If you'd like to
+support the maintainers of React Table, please consider enabling installation
+analytics with [Scarf](https://www.npmjs.com/package/@scarf/scarf) by setting
+the environment variable `SCARF_ANALYTICS=true` before you install. Analytics
+are turned off by default.
 
 ```bash
+# If you'd like to support react-table by sending installation analytics:
+$ export SCARF_ANALYTICS=true
+
 # NPM
 $ npm install react-table
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,21 +1,20 @@
 # Installation
 
-Install React Table as a dependency using `npm` or `yarn`. If you'd like to
-support the maintainers of React Table, please consider enabling installation
-analytics with [Scarf](https://www.npmjs.com/package/@scarf/scarf) by setting
-the environment variable `SCARF_ANALYTICS=true` before you install. Analytics
-are turned off by default.
+Install React Table as a dependency using `npm` or `yarn`. 
 
 ```bash
-# If you'd like to support react-table by sending installation analytics:
-$ export SCARF_ANALYTICS=true
-
 # NPM
 $ npm install react-table
 
 # Yarn
 $ yarn add react-table
 ```
+
+React Table uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect
+anonymized installation analytics. These anlytics help support the maintainers
+of this library. However, if you'd like to opt out, you can do so by setting the
+environment variable `SCARF_ANALYTICS=false` before you install, or by setting
+`scarfSettings.enabled = false` in your project's `package.json`
 
 To import React Table:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Install React Table as a dependency using `npm` or `yarn`. 
+Install React Table as a dependency using `npm` or `yarn`
 
 ```bash
 # NPM

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "README.md"
   ],
   "browserslist": "> 0.25%, not dead",
+  "dependencies": {
+    "@scarf/scarf": "^0.1.3"
+  },
   "peerDependencies": {
     "react": "^16.8.3"
   },
@@ -47,7 +50,6 @@
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
     "@babel/runtime": "^7.7.2",
-    "@scarf/scarf": "^0.1.1",
     "@svgr/rollup": "^4.3.3",
     "@testing-library/dom": "^6.10.1",
     "@testing-library/jest-dom": "^4.2.4",
@@ -93,8 +95,5 @@
     "rollup-plugin-size-snapshot": "^0.10.0",
     "rollup-plugin-terser": "^5.1.2",
     "serve": "^11.2.0"
-  },
-  "scarfSettings": {
-    "defaultOptIn": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
     "@babel/runtime": "^7.7.2",
+    "@scarf/scarf": "^0.1.1",
     "@svgr/rollup": "^4.3.3",
     "@testing-library/dom": "^6.10.1",
     "@testing-library/jest-dom": "^4.2.4",
@@ -92,5 +93,8 @@
     "rollup-plugin-size-snapshot": "^0.10.0",
     "rollup-plugin-terser": "^5.1.2",
     "serve": "^11.2.0"
+  },
+  "scarfSettings": {
+    "defaultOptIn": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,6 +992,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@scarf/scarf@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-0.1.1.tgz#ab9bdfb4439f7934f616ae9725adb04ff4237784"
+  integrity sha512-ZQVMR79JRFGBhdxyjV15+84T9N2YCw65ilteutQ+/ZV08NUoyaxZZqd2qHGZ0cAMtEYZHtAtBh2OUB7PwhsKbg==
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,10 +992,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@scarf/scarf@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-0.1.1.tgz#ab9bdfb4439f7934f616ae9725adb04ff4237784"
-  integrity sha512-ZQVMR79JRFGBhdxyjV15+84T9N2YCw65ilteutQ+/ZV08NUoyaxZZqd2qHGZ0cAMtEYZHtAtBh2OUB7PwhsKbg==
+"@scarf/scarf@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-0.1.3.tgz#536f4fe54c613fca20f84dc7700ed3b8f1fb73cf"
+  integrity sha512-ftMyZO7Mi8JQh8XLBcuH3erPGmT4CU4s131nsZIDC7/PYXxaDCJtOzbz3okH0YiTAif+DSIlFhX6d7FXLOtnvA==
 
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION
This change adds a `devDependency` on Scarf for installation analytics to support the maintainers of React Table. 

Discussion from everyone is welcome! Some background on the library and the problem it's solving can be found in this post here: [https://github.com/scarf-sh/scarf-js/blob/master/WHY.org](https://github.com/scarf-sh/scarf-js/blob/master/WHY.org). The package README ([https://github.com/scarf-sh/scarf-js](https://github.com/scarf-sh/scarf-js)) has more info on exactly what data is sent on each install. 

The analytics introduced here are opt-out by default, so data will only be collected from users who explicitly enable it. Because it has been added as a `devDependency`, it also won't be triggered during production builds that depend on `react-table`.

The data Scarf collects will help maintainers by keeping them informed about how the package is being used and will help drive sponsorship to support all the work that goes into React Table. 
