### PR TITLE
Update autoReset FAQ docs example

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -108,13 +108,13 @@ React.useEffect(() => {
 
 useTable({
   ...
-  autoResetPage: !skipPageReset,
-  autoResetExpanded: !skipPageReset,
-  autoResetGroupBy: !skipPageReset,
-  autoResetSelectedRows: !skipPageReset,
-  autoResetSortBy: !skipPageReset,
-  autoResetFilters: !skipPageReset,
-  autoResetRowState: !skipPageReset,
+  autoResetPage: !skipPageResetRef.current,
+  autoResetExpanded: !skipPageResetRef.current,
+  autoResetGroupBy: !skipPageResetRef.current,
+  autoResetSelectedRows: !skipPageResetRef.current,
+  autoResetSortBy: !skipPageResetRef.current,
+  autoResetFilters: !skipPageResetRef.current,
+  autoResetRowState: !skipPageResetRef.current,
 })
 ```
 


### PR DESCRIPTION
This change updates the example to replace an undeclared variable with the usage of `skipPageResetRef`. I was reading through this docs page today and believe this is the correct usage of `React.useRef()` in the context of this example.