### PR TITLE
Add cell’s value to its renderer back

### DIFF
--- a/docs/api/useTable.md
+++ b/docs/api/useTable.md
@@ -101,7 +101,7 @@ The following options are supported on any column object you can pass to `column
   - If a function/component is passed, it will be used for formatting the header value, eg. You can use a `Header` function to dynamically format the header using any table or column state.
 - `Cell: Function | React.Component => JSX`
   - Optional
-  - Defaults to `({ cell: { value } }) => String(value)`
+  - Defaults to `({ value }) => String(value)`
   - Receives the table instance and cell model as props
   - Must return valid JSX
   - This function (or component) is primarily used for formatting the column value, eg. If your column accessor returns a date object, you can use a `Cell` function to format that date to a readable format.

--- a/examples/editable-data/src/App.js
+++ b/examples/editable-data/src/App.js
@@ -46,7 +46,7 @@ const Styles = styled.div`
 
 // Create an editable cell renderer
 const EditableCell = ({
-  cell: { value: initialValue },
+  value: initialValue,
   row: { index },
   column: { id },
   updateMyData, // This is a custom function that we supplied to our table instance

--- a/examples/grouping-column/src/App.js
+++ b/examples/grouping-column/src/App.js
@@ -260,7 +260,7 @@ function App() {
             // then sum any of those counts if they are
             // aggregated further
             aggregate: 'count',
-            Aggregated: ({ cell: { value } }) => `${value} Names`,
+            Aggregated: ({ value }) => `${value} Names`,
           },
           {
             Header: 'Last Name',
@@ -270,7 +270,7 @@ function App() {
             // being aggregated, then sum those counts if
             // they are aggregated further
             aggregate: 'uniqueCount',
-            Aggregated: ({ cell: { value } }) => `${value} Unique Names`,
+            Aggregated: ({ value }) => `${value} Unique Names`,
           },
         ],
       },
@@ -282,14 +282,14 @@ function App() {
             accessor: 'age',
             // Aggregate the average age of visitors
             aggregate: 'average',
-            Aggregated: ({ cell: { value } }) => `${value} (avg)`,
+            Aggregated: ({ value }) => `${value} (avg)`,
           },
           {
             Header: 'Visits',
             accessor: 'visits',
             // Aggregate the sum of all visits
             aggregate: 'sum',
-            Aggregated: ({ cell: { value } }) => `${value} (total)`,
+            Aggregated: ({ value }) => `${value} (total)`,
           },
           {
             Header: 'Status',
@@ -300,7 +300,7 @@ function App() {
             accessor: 'progress',
             // Use our custom roundedMedian aggregator
             aggregate: roundedMedian,
-            Aggregated: ({ cell: { value } }) => `${value} (med)`,
+            Aggregated: ({ value }) => `${value} (med)`,
           },
         ],
       },

--- a/examples/grouping/src/App.js
+++ b/examples/grouping/src/App.js
@@ -197,7 +197,7 @@ function App() {
             // then sum any of those counts if they are
             // aggregated further
             aggregate: 'count',
-            Aggregated: ({ cell: { value } }) => `${value} Names`,
+            Aggregated: ({ value }) => `${value} Names`,
           },
           {
             Header: 'Last Name',
@@ -207,7 +207,7 @@ function App() {
             // being aggregated, then sum those counts if
             // they are aggregated further
             aggregate: 'uniqueCount',
-            Aggregated: ({ cell: { value } }) => `${value} Unique Names`,
+            Aggregated: ({ value }) => `${value} Unique Names`,
           },
         ],
       },
@@ -219,15 +219,14 @@ function App() {
             accessor: 'age',
             // Aggregate the average age of visitors
             aggregate: 'average',
-            Aggregated: ({ cell: { value } }) =>
-              `${Math.round(value * 100) / 100} (avg)`,
+            Aggregated: ({ value }) => `${Math.round(value * 100) / 100} (avg)`,
           },
           {
             Header: 'Visits',
             accessor: 'visits',
             // Aggregate the sum of all visits
             aggregate: 'sum',
-            Aggregated: ({ cell: { value } }) => `${value} (total)`,
+            Aggregated: ({ value }) => `${value} (total)`,
           },
           {
             Header: 'Status',
@@ -238,7 +237,7 @@ function App() {
             accessor: 'progress',
             // Use our custom roundedMedian aggregator
             aggregate: roundedMedian,
-            Aggregated: ({ cell: { value } }) => `${value} (med)`,
+            Aggregated: ({ value }) => `${value} (med)`,
           },
         ],
       },

--- a/examples/kitchen-sink-controlled/src/App.js
+++ b/examples/kitchen-sink-controlled/src/App.js
@@ -57,7 +57,7 @@ const Styles = styled.div`
 
 // Create an editable cell renderer
 const EditableCell = ({
-  cell: { value: initialValue },
+  value: initialValue,
   row: { index },
   column: { id },
   updateMyData, // This is a custom function that we supplied to our table instance
@@ -400,8 +400,8 @@ function Table({ columns, data, updateMyData, skipPageReset }) {
           })}
         </tbody>
       </table>
-      {/* 
-        Pagination can be built however you'd like. 
+      {/*
+        Pagination can be built however you'd like.
         This is just a very basic UI implementation:
       */}
       <div className="pagination">
@@ -514,7 +514,7 @@ function App() {
             // then sum any of those counts if they are
             // aggregated further
             aggregate: 'count',
-            Aggregated: ({ cell: { value } }) => `${value} Names`,
+            Aggregated: ({ value }) => `${value} Names`,
           },
           {
             Header: 'Last Name',
@@ -526,7 +526,7 @@ function App() {
             // being aggregated, then sum those counts if
             // they are aggregated further
             aggregate: 'uniqueCount',
-            Aggregated: ({ cell: { value } }) => `${value} Unique Names`,
+            Aggregated: ({ value }) => `${value} Unique Names`,
           },
         ],
       },
@@ -540,7 +540,7 @@ function App() {
             filter: 'equals',
             // Aggregate the average age of visitors
             aggregate: 'average',
-            Aggregated: ({ cell: { value } }) => `${value} (avg)`,
+            Aggregated: ({ value }) => `${value} (avg)`,
           },
           {
             Header: 'Visits',
@@ -549,7 +549,7 @@ function App() {
             filter: 'between',
             // Aggregate the sum of all visits
             aggregate: 'sum',
-            Aggregated: ({ cell: { value } }) => `${value} (total)`,
+            Aggregated: ({ value }) => `${value} (total)`,
           },
           {
             Header: 'Status',
@@ -564,7 +564,7 @@ function App() {
             filter: filterGreaterThan,
             // Use our custom roundedMedian aggregator
             aggregate: roundedMedian,
-            Aggregated: ({ cell: { value } }) => `${value} (med)`,
+            Aggregated: ({ value }) => `${value} (med)`,
           },
         ],
       },

--- a/examples/kitchen-sink/src/App.js
+++ b/examples/kitchen-sink/src/App.js
@@ -57,7 +57,7 @@ const Styles = styled.div`
 
 // Create an editable cell renderer
 const EditableCell = ({
-  cell: { value: initialValue },
+  value: initialValue,
   row: { index },
   column: { id },
   updateMyData, // This is a custom function that we supplied to our table instance
@@ -411,8 +411,8 @@ function Table({ columns, data, updateMyData, skipReset }) {
           })}
         </tbody>
       </table>
-      {/* 
-        Pagination can be built however you'd like. 
+      {/*
+        Pagination can be built however you'd like.
         This is just a very basic UI implementation:
       */}
       <div className="pagination">
@@ -543,7 +543,7 @@ function App() {
             // then sum any of those counts if they are
             // aggregated further
             aggregate: 'count',
-            Aggregated: ({ cell: { value } }) => `${value} Names`,
+            Aggregated: ({ value }) => `${value} Names`,
           },
           {
             Header: 'Last Name',
@@ -555,7 +555,7 @@ function App() {
             // being aggregated, then sum those counts if
             // they are aggregated further
             aggregate: 'uniqueCount',
-            Aggregated: ({ cell: { value } }) => `${value} Unique Names`,
+            Aggregated: ({ value }) => `${value} Unique Names`,
           },
         ],
       },
@@ -569,7 +569,7 @@ function App() {
             filter: 'equals',
             // Aggregate the average age of visitors
             aggregate: 'average',
-            Aggregated: ({ cell: { value } }) => `${value} (avg)`,
+            Aggregated: ({ value }) => `${value} (avg)`,
           },
           {
             Header: 'Visits',
@@ -578,7 +578,7 @@ function App() {
             filter: 'between',
             // Aggregate the sum of all visits
             aggregate: 'sum',
-            Aggregated: ({ cell: { value } }) => `${value} (total)`,
+            Aggregated: ({ value }) => `${value} (total)`,
           },
           {
             Header: 'Status',
@@ -593,7 +593,7 @@ function App() {
             filter: filterGreaterThan,
             // Use our custom roundedMedian aggregator
             aggregate: roundedMedian,
-            Aggregated: ({ cell: { value } }) => `${value} (med)`,
+            Aggregated: ({ value }) => `${value} (med)`,
           },
         ],
       },

--- a/examples/material-UI-enhanced-table/src/components/EnhancedTable.js
+++ b/examples/material-UI-enhanced-table/src/components/EnhancedTable.js
@@ -47,7 +47,7 @@ const inputStyle = {
 
 // Create an editable cell renderer
 const EditableCell = ({
-  cell: { value: initialValue },
+  value: initialValue,
   row: { index },
   column: { id },
   updateMyData, // This is a custom function that we supplied to our table instance

--- a/examples/pivoting/src/App.js
+++ b/examples/pivoting/src/App.js
@@ -233,8 +233,8 @@ function App() {
         accessor: d => new Date(d.date),
         sortType: 'basic',
         aggregate: 'count',
-        Cell: ({ cell: { value } }) => (value ? dayjs(value).format('l') : ''),
-        Aggregated: ({ cell: { value } }) => `${value} Orders`,
+        Cell: ({ value }) => (value ? dayjs(value).format('l') : ''),
+        Aggregated: ({ value }) => `${value} Orders`,
       },
       {
         Header: 'Employee',
@@ -260,7 +260,7 @@ function App() {
         Header: 'Unit Cost',
         accessor: 'unitCost',
         aggregate: 'average',
-        Cell: ({ cell: { value } }) =>
+        Cell: ({ value }) =>
           typeof value !== 'undefined' ? (
             <div
               style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
@@ -273,7 +273,7 @@ function App() {
         Header: 'Total',
         accessor: 'total',
         aggregate: 'sum',
-        Cell: ({ cell: { value } }) =>
+        Cell: ({ value }) =>
           typeof value !== 'undefined' ? (
             <div
               style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}

--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -402,10 +402,12 @@ export const useTable = (props, ...plugins) => {
 
       // Build the visible cells for each row
       row.allCells = allColumns.map(column => {
+        const value = row.values[column.id]
+
         const cell = {
           column,
           row,
-          value: row.values[column.id],
+          value,
         }
 
         // Give each cell a getCellProps base
@@ -418,7 +420,7 @@ export const useTable = (props, ...plugins) => {
         cell.render = makeRenderer(getInstance(), column, {
           row,
           cell,
-          value: cell.value,
+          value,
         })
 
         return cell

--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -418,6 +418,7 @@ export const useTable = (props, ...plugins) => {
         cell.render = makeRenderer(getInstance(), column, {
           row,
           cell,
+          value: cell.value,
         })
 
         return cell

--- a/src/plugin-hooks/tests/useAbsoluteLayout.test.js
+++ b/src/plugin-hooks/tests/useAbsoluteLayout.test.js
@@ -31,7 +31,7 @@ const data = [
 ]
 
 const defaultColumn = {
-  Cell: ({ cell: { value }, column: { id } }) => `${id}: ${value}`,
+  Cell: ({ value, column: { id } }) => `${id}: ${value}`,
   width: 200,
   minWidth: 100,
   maxWidth: 300,

--- a/src/plugin-hooks/tests/useBlockLayout.test.js
+++ b/src/plugin-hooks/tests/useBlockLayout.test.js
@@ -31,7 +31,7 @@ const data = [
 ]
 
 const defaultColumn = {
-  Cell: ({ cell: { value }, column: { id } }) => `${id}: ${value}`,
+  Cell: ({ value, column: { id } }) => `${id}: ${value}`,
   width: 200,
   minWidth: 100,
   maxWidth: 300,

--- a/src/plugin-hooks/tests/useFilters.test.js
+++ b/src/plugin-hooks/tests/useFilters.test.js
@@ -40,7 +40,7 @@ const makeData = () => [
 ]
 
 const defaultColumn = {
-  Cell: ({ cell: { value }, column: { id } }) => `${id}: ${value}`,
+  Cell: ({ value, column: { id } }) => `${id}: ${value}`,
   Filter: ({ column: { filterValue, setFilter } }) => (
     <input
       value={filterValue || ''}

--- a/src/plugin-hooks/tests/useFiltersAndRowSelect.test.js
+++ b/src/plugin-hooks/tests/useFiltersAndRowSelect.test.js
@@ -106,7 +106,7 @@ function Table({ columns, data }) {
 }
 
 const defaultColumn = {
-  Cell: ({ cell: { value }, column: { id } }) => `${id}: ${value}`,
+  Cell: ({ value, column: { id } }) => `${id}: ${value}`,
   Filter: ({ column: { filterValue, setFilter } }) => (
     <input
       value={filterValue || ''}

--- a/src/plugin-hooks/tests/useFlexLayout.test.js
+++ b/src/plugin-hooks/tests/useFlexLayout.test.js
@@ -31,7 +31,7 @@ const data = [
 ]
 
 const defaultColumn = {
-  Cell: ({ cell: { value }, column: { id } }) => `${id}: ${value}`,
+  Cell: ({ value, column: { id } }) => `${id}: ${value}`,
   width: 200,
   minWidth: 100,
   maxWidth: 300,

--- a/src/plugin-hooks/tests/useGroupBy.test.js
+++ b/src/plugin-hooks/tests/useGroupBy.test.js
@@ -48,7 +48,7 @@ const data = [
 ]
 
 const defaultColumn = {
-  Cell: ({ cell: { value }, column: { id } }) => `${id}: ${value}`,
+  Cell: ({ value, column: { id } }) => `${id}: ${value}`,
   Filter: ({ filterValue, setFilter }) => (
     <input
       value={filterValue || ''}
@@ -160,14 +160,14 @@ function App() {
             Header: 'First Name',
             accessor: 'firstName',
             aggregate: 'count',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `First Name Aggregated: ${value} Names`,
           },
           {
             Header: 'Last Name',
             accessor: 'lastName',
             aggregate: 'uniqueCount',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Last Name Aggregated: ${value} Unique Names`,
           },
         ],
@@ -179,14 +179,14 @@ function App() {
             Header: 'Age',
             accessor: 'age',
             aggregate: 'average',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Age Aggregated: ${value} (avg)`,
           },
           {
             Header: 'Visits',
             accessor: 'visits',
             aggregate: 'sum',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Visits Aggregated: ${value} (total)`,
           },
           {
@@ -194,7 +194,7 @@ function App() {
             id: 'minVisits',
             accessor: 'visits',
             aggregate: 'min',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Visits Aggregated: ${value} (min)`,
           },
           {
@@ -202,7 +202,7 @@ function App() {
             id: 'maxVisits',
             accessor: 'visits',
             aggregate: 'max',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Visits Aggregated: ${value} (max)`,
           },
           {
@@ -210,14 +210,14 @@ function App() {
             id: 'minMaxVisits',
             accessor: 'visits',
             aggregate: 'minMax',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Visits Aggregated: ${value} (minMax)`,
           },
           {
             Header: 'Status',
             accessor: 'status',
             aggregate: 'unique',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Visits Aggregated: ${value.join(', ')} (unique)`,
           },
           {
@@ -225,7 +225,7 @@ function App() {
             accessor: 'progress',
             id: 'progress',
             aggregate: 'median',
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Process Aggregated: ${value} (median)`,
           },
           {
@@ -233,7 +233,7 @@ function App() {
             accessor: 'progress',
             id: 'progressRounded',
             aggregate: roundedMedian,
-            Aggregated: ({ cell: { value } }) =>
+            Aggregated: ({ value }) =>
               `Process Aggregated: ${value} (rounded median)`,
           },
         ],

--- a/src/plugin-hooks/tests/useSortBy.test.js
+++ b/src/plugin-hooks/tests/useSortBy.test.js
@@ -31,7 +31,7 @@ const data = [
 ]
 
 const defaultColumn = {
-  Cell: ({ cell: { value }, column: { id } }) => `${id}: ${value}`,
+  Cell: ({ value, column: { id } }) => `${id}: ${value}`,
 }
 
 function Table({ columns, data }) {

--- a/src/publicUtils.js
+++ b/src/publicUtils.js
@@ -7,7 +7,7 @@ export const actions = {
 }
 
 export const defaultColumn = {
-  Cell: ({ cell: { value = '' } }) => value,
+  Cell: ({ value = '' }) => value,
   width: 150,
   minWidth: 0,
   maxWidth: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
One thing that I wondered about and wasn't sure why it was changed from v6 to v7 is the Cell renderer API, where the value was only accessible inside the `cell`. From how I look at it, nothing stops us from returning it back, as there shouldn't be any collisions with the instance's properties and methods, and it would make both migrating from v6 much easier, and writing new Cell code much simpler as well.

We can still keep `cell` for stuff like in the `useRowState` and not to break anything for those who already use the v7's API.

If there was a reason to remove the `value` from the Cell's props, I'd be happy to talk about this in order to find a better solution for the underlying problem.