### PR TITLE
fix: move docz to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,6 @@
     "README.md"
   ],
   "browserslist": "> 0.25%, not dead",
-  "dependencies": {
-    "docz": "^2.2.0",
-    "gatsby-theme-docz": "^2.2.0"
-  },
   "peerDependencies": {
     "react": "^16.8.3"
   },
@@ -64,6 +60,7 @@
     "babel-jest": "^24.9.0",
     "core-js": "3.4.1",
     "cross-env": "^6.0.3",
+    "docz": "^2.2.0",
     "eslint": "6.6.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-config-react-app": "^5.0.2",
@@ -78,6 +75,7 @@
     "eslint-plugin-react": "7.16.0",
     "eslint-plugin-react-hooks": "2.3.0",
     "eslint-plugin-standard": "^4.0.1",
+    "gatsby-theme-docz": "^2.2.0",
     "is-ci-cli": "^2.0.0",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,6 +1883,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/mkdirp@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
+  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "13.9.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.2.tgz#ace1880c03594cc3e80206d96847157d8e7fa349"


### PR DESCRIPTION
Relates to #2013 

This PR moves docz-related dependencies to the package.json's devDependencies block.

I recently upgraded to the latest version of react-table and found that gatsby and its related dependencies were added to my project's yarn.lock file. By moving docz to devDependencies, installers of the react-table package will not have to download gatsby etc. into their node_modules and yarn.lock file.