### PR TITLE
Add `scripts/` dir to package `"files"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "dist",
     "LICENCE",
     "package.json",
-    "README.md"
+    "README.md",
+    "scripts/"
   ],
   "browserslist": "> 0.25%, not dead",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "src/**/*.js",
     "index.d.ts",
     "dist",
-    "LICENCE",
-    "package.json",
     "README.md",
     "scripts/"
   ],


### PR DESCRIPTION
Fixes #2082.

- Include `scripts/` in `npm` tarball so `postinstall` script does not fail for users.
- Remove `LICENCE` and `package.json` entries from `"files"` since they are [always added by default](https://docs.npmjs.com/files/package.json#files).