### PR TITLE
fix: Docs | Fix broken links to FAQ 

### DIFF
--- a/docs/api/useFilters.md
+++ b/docs/api/useFilters.md
@@ -36,7 +36,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `filters` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](/faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Column Options
 

--- a/docs/api/useGlobalFilter.md
+++ b/docs/api/useGlobalFilter.md
@@ -40,7 +40,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `globalFilter` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](./faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](/faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Column Options
 

--- a/docs/api/useRowSelect.md
+++ b/docs/api/useRowSelect.md
@@ -28,7 +28,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `selectedRowIds` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](./faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](/faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Instance Properties
 

--- a/docs/api/useRowState.md
+++ b/docs/api/useRowState.md
@@ -36,7 +36,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `rowState` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](./faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](/faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Instance Properties
 


### PR DESCRIPTION
I noticed that I couldn't find `how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)` while going through the docs. After running the docs locally, some links to this page were returning 404s.

![Screenshot 2020-04-11 at 13 43 14](https://user-images.githubusercontent.com/12698531/79068997-b1ff0000-7cc2-11ea-90fa-d586e2d0dc58.png)

I have fixed the broken links and noticed that `api/useFilters` was updated a couple of weeks ago (https://github.com/tannerlinsley/react-table/pull/2067). For consistency, that one has been updated as well so that all faq links point to `/faq#id`.