### PR TITLE
Update @scarf/scarf version to ^1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
-    "@scarf/scarf": "^0.1.5"
+    "@scarf/scarf": "^1.0.4"
   },
   "peerDependencies": {
     "react": "^16.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@scarf/scarf@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-0.1.5.tgz#fc4cc88294eca336eed9a91549180346de5e6946"
-  integrity sha512-Fx6atDc7JM1r0WkPCDhNetVZNp+DO21q/HGlomAKBG+k8vb1B8fg8Yige4oCf1P9OWTZWm5tM5i3jlXhrSbNOg==
+"@scarf/scarf@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.0.4.tgz#d7c09e7d38428123df18a8d83a4bb5d09517d952"
+  integrity sha512-lkhjzeYyYAG4VvdrjvbZCOYzXH5vCwfzYj9xJ4zHDgyYIOzObZwcsbW6W1q5Z4tywrb14oG/tfsFAMMQPCTFqw==
 
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION
### Change description

This change is just the dependency version bump for scarf. It's needed in order to actually pull down the fix that will resolve things for #2169. 

### Background

Some improvements went into the newest scarf version beyond this bugfix, so we bumped the minor version going from `0.1.5` to `0.2.0`. I expected this change to be pushed to react-table users, as it was pinned to `^0.1.5`, and this is a backwards-compatible change. I didn't realize that npm actually treats <1.0.0 versions a bit different when it comes to the caret (https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004). So react-table is currently only getting updates for scarf `<0.2` right now. With this update, it will be on the new `1.0.4` release, which happens to be identical to `0.2.0`. The next breaking change, if ever, will bring scarf to `2.0.0` and will not be automatically pushed to react-table users, as expected.

Apologies for my own misunderstanding of npm's semver handling that caused this to be needed in the first place, won't happen again. :)