### PR TITLE
fix: Expanding example

### DIFF
--- a/docs/examples/simple.mdx
+++ b/docs/examples/simple.mdx
@@ -58,7 +58,7 @@ All of these examples use automatic state management, meaning, they don't hoist 
 ## Expanding
 
 - [Source](https://github.com/tannerlinsley/react-table/tree/master/examples/expanding)
-- [Open in CodeSandbox](https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/sub-components)
+- [Open in CodeSandbox](https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/expanding)
 
 ## Sub Components
 


### PR DESCRIPTION
Wrong url of CodeSandbox for Expanding example