### PR TITLE
Add useAsyncDebounce to filtering example

### DIFF
--- a/examples/filtering/src/App.js
+++ b/examples/filtering/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useTable, useFilters, useGlobalFilter } from 'react-table'
+import { useTable, useFilters, useGlobalFilter, useAsyncDebounce } from 'react-table'
 // A great library for fuzzy filtering/sorting items
 import matchSorter from 'match-sorter'
 
@@ -42,14 +42,19 @@ function GlobalFilter({
   setGlobalFilter,
 }) {
   const count = preGlobalFilteredRows.length
+  const [value, setValue] = React.useState(globalFilter)
+  const onChange = useAsyncDebounce(value => {
+    setGlobalFilter(value || undefined)
+  }, 200)
 
   return (
     <span>
       Search:{' '}
       <input
-        value={globalFilter || ''}
+        value={value || ""}
         onChange={e => {
-          setGlobalFilter(e.target.value || undefined) // Set undefined to remove the filter entirely
+          setValue(e.target.value);
+          onChange(e.target.value);
         }}
         placeholder={`${count} records...`}
         style={{


### PR DESCRIPTION
When filtering large grids (or the browser runs on a slow computer),
typing in the search box can lack a bit of feedback, as the search box
is only updated with the characters the user types together with the
filtered table.

It took me a small while to figure out how to correctly use
useAsyncDebounce and useState to debounce the onChange event handler, so
I thought it might be useful in the filtering example.