### PR TITLE
Fix bootstrap ui example

### DIFF
--- a/examples/bootstrap-UI-components/README.md
+++ b/examples/bootstrap-UI-components/README.md
@@ -2,5 +2,5 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/material-UI-components)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/bootstrap-UI-components)
 - `yarn` and `yarn start` to run and edit the example

--- a/examples/bootstrap-UI-components/src/App.js
+++ b/examples/bootstrap-UI-components/src/App.js
@@ -36,9 +36,9 @@ function Table({ columns, data }) {
             <tr {...row.getRowProps()}>
               {row.cells.map(cell => {
                 return (
-                  <th {...cell.getCellProps()}>
+                  <td {...cell.getCellProps()}>
                     {cell.render('Cell')}
-                  </th>
+                  </td>
                 )
               })}
             </tr>


### PR DESCRIPTION
Bootstrap UI example has an incorrect example URL and was using TH's for the table rows