### PR TITLE
docs(readme): remove unnecessary li closing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ This library is being built and maintained by me, @tannerlinsley and I am always
 
 [![Supporters](https://raw.githubusercontent.com/tannerlinsley/files/master/sponsorships/supporters.png)](https://github.com/sponsors/tannerlinsley)
 
-- Jon Eickmeier</li>
-- <a href="https://github.com/rhefner">Richard Hefner (@rhefner)</a></li>
-- <a href="https://gitHub.com/snorkypie"> Steeve Lennmark (@snorkypie)</a></li>
+- Jon Eickmeier
+- <a href="https://github.com/rhefner">Richard Hefner (@rhefner)</a>
+- <a href="https://gitHub.com/snorkypie"> Steeve Lennmark (@snorkypie)</a>
 
 [![Fans](https://raw.githubusercontent.com/tannerlinsley/files/master/sponsorships/fans.png)](https://github.com/sponsors/tannerlinsley)
 


### PR DESCRIPTION
I got an error from gatsby-plugin-mdx because of the closing li tags

```
"gatsby-plugin-mdx" threw an error while running the onCreateNode lifecycle:

unknown: Expected corresponding JSX closing tag for <ul> (155:42)

  153 | <p><a parentName="p" {...{"href":"https://github.com/sponsors/tannerlinsley"}}><img parentName="a" {...{"src":"https://raw.githubusercontent.com/tannerlinsley/files/master/sponsorships/supporters.png","alt":"Supporters"}}></img></a></p>
  154 | <ul>
> 155 | <li parentName="ul">{`Jon Eickmeier`}</li></li>

SyntaxError: unknown: Expected corresponding JSX closing tag for <ul> (155:42)
```