### PR TITLE
fix: detect browser support for passive events

### DIFF
--- a/src/plugin-hooks/useResizeColumns.js
+++ b/src/plugin-hooks/useResizeColumns.js
@@ -6,7 +6,7 @@ import {
   ensurePluginOrder,
 } from '../publicUtils'
 
-import { getFirstDefined } from '../utils'
+import { getFirstDefined, passiveEventSupported } from '../utils'
 
 // Default Column
 defaultColumn.canResize = true
@@ -95,12 +95,19 @@ const defaultGetResizerProps = (props, { instance, header }) => {
     const events = isTouchEvent
       ? handlersAndEvents.touch
       : handlersAndEvents.mouse
-    document.addEventListener(events.moveEvent, events.moveHandler, {
-      passive: false,
-    })
-    document.addEventListener(events.upEvent, events.upHandler, {
-      passive: false,
-    })
+    const passiveIfSupported = passiveEventSupported()
+      ? { passive: false }
+      : false
+    document.addEventListener(
+      events.moveEvent,
+      events.moveHandler,
+      passiveIfSupported
+    )
+    document.addEventListener(
+      events.upEvent,
+      events.upHandler,
+      passiveIfSupported
+    )
 
     dispatch({
       type: actions.columnStartResizing,

--- a/src/utils.js
+++ b/src/utils.js
@@ -280,6 +280,29 @@ export function unpreparedAccessWarning() {
   )
 }
 
+let passiveSupported = null
+export function passiveEventSupported() {
+  // memoize support to avoid adding multiple test events
+  if (typeof passiveSupported === 'boolean') return passiveSupported
+
+  let supported = false
+  try {
+    const options = {
+      get passive() {
+        supported = true
+        return false
+      },
+    }
+
+    window.addEventListener('test', null, options)
+    window.removeEventListener('test', null, options)
+  } catch (err) {
+    supported = false
+  }
+  passiveSupported = supported
+  return passiveSupported
+}
+
 //
 
 const reOpenBracket = /\[/g


### PR DESCRIPTION
This fixes #2302 and brings IE support to the useResizeColumns plugin. It adds a feature check function which performs a memoized check for using `{ passive: false }` in an event handler.

It seems that with IE 11, the event could be added with the unsupported option, but then the event could never be removed. This caused a move handler to be added on every mousedown on a resizer, and the rezising would never stop.

More info on the feature check:
- https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
- https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener