### PR TITLE
Feature/Fix: Add filterTypes: includesSome & includesValue

### DIFF
--- a/src/filterTypes.js
+++ b/src/filterTypes.js
@@ -64,6 +64,32 @@ export const includesAll = (rows, ids, filterValue) => {
 
 includesAll.autoRemove = val => !val || !val.length
 
+export const includesSome = (rows, ids, filterValue) => {
+  return rows.filter(row => {
+    return ids.some(id => {
+      const rowValue = row.values[id]
+      return (
+        rowValue &&
+        rowValue.length &&
+        filterValue.some(val => rowValue.includes(val))
+      )
+    })
+  })
+}
+
+includesSome.autoRemove = val => !val || !val.length
+
+export const includesValue = (rows, ids, filterValue) => {
+  return rows.filter(row => {
+    return ids.some(id => {
+      const rowValue = row.values[id]
+      return filterValue.includes(rowValue)
+    })
+  })
+}
+
+includesValue.autoRemove = val => !val || !val.length
+
 export const exact = (rows, ids, filterValue) => {
   return rows.filter(row => {
     return ids.some(id => {


### PR DESCRIPTION
This is sort of a fix for #2174.

In a recent release, #2001 changed the behavior of the `includes` filter to check for a single filter value within an array or string row value. This broke some existing usages of the previous `includes` filter, which expected the previous behavior (checking for a single row value within an array or string filter value).

`includes` is a very vague name/name-prefix to begin with (especially without any documentation yet around built-in filterTypes), but I expect that the new behavior is probably a more common use-case, especially scenarios where the row value is a string. From what I've seen, most of the codesandbox examples expect this behavior too.

So, instead of reverting #2001, I think it makes more sense to add a new filter to reintroduce the previous `includes` behavior, which I've implemented here as `includesValue`.

While I was in there, I also added another filter `includesSome`, which is a natural complement to the existing `includesAll` filter.