### PR TITLE
Fix incorrect documentation for column header accessor

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,11 +35,11 @@ const columns = React.useMemo(
   () => [
     {
       Header: 'Column 1',
-      accessor: 'col1', // accessor is the "key" in the data
+      id: 'col1', // accessor is the "key" in the data
     },
     {
       Header: 'Column 2',
-      accessor: 'col2',
+      id: 'col2',
     },
   ],
   []


### PR DESCRIPTION
Currently as of react-table 7.x the accessor field of the columns used without id errors (based on the typings of @types/react-table)
In order for this to not error by default switch to `id` instead of `accessor`. 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ac0327a3ddfe6dac85bf13b99363e58925ee56f2/types/react-table/index.d.ts#L78