### PR TITLE
feat: add initialRows property on instance

### DIFF
--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -210,6 +210,7 @@ export const useTable = (props, ...plugins) => {
 
   Object.assign(getInstance(), {
     rows,
+    initialRows: [...rows],
     flatRows,
     rowsById,
     // materializedColumns,


### PR DESCRIPTION
Adding initial rows property, which helps in getting rows before sorting, filtering etc.