### PR TITLE
fix(layout plugins): add support for footers in layout plugins

### DIFF
--- a/docs/api/useAbsoluteLayout.md
+++ b/docs/api/useAbsoluteLayout.md
@@ -37,6 +37,18 @@
   - **Usage Required**
   - This core prop getter is required to to enable absolute layout for headers
 
+### FooterGroup Properties
+
+- `getFooterGroupProps`
+  - **Usage Required**
+  - This core prop getter is required to to enable absolute layout for footers
+
+### Footer Properties
+
+- `getFooterProps`
+  - **Usage Required**
+  - This core prop getter is required to to enable absolute layout for footers
+
 ### Example
 
 - [Source](https://github.com/tannerlinsley/react-table/tree/master/examples/absolute-layout)

--- a/docs/api/useBlockLayout.md
+++ b/docs/api/useBlockLayout.md
@@ -31,6 +31,18 @@
   - **Usage Required**
   - This core prop getter is required to to enable absolute layout for headers
 
+### FooterGroup Properties
+
+- `getFooterGroupProps`
+  - **Usage Required**
+  - This core prop getter is required to to enable absolute layout for footers
+
+### Footer Properties
+
+- `getFooterProps`
+  - **Usage Required**
+  - This core prop getter is required to to enable absolute layout for footers
+
 ### Example
 
 - [Source](https://github.com/tannerlinsley/react-table/tree/master/examples/block-layout)

--- a/docs/api/useFlexLayout.md
+++ b/docs/api/useFlexLayout.md
@@ -37,6 +37,18 @@
   - **Usage Required**
   - This core prop getter is required to to enable absolute layout for headers
 
+### FooterGroup Properties
+
+- `getFooterGroupProps`
+  - **Usage Required**
+  - This core prop getter is required to to enable absolute layout for footers
+
+### Footer Properties
+
+- `getFooterProps`
+  - **Usage Required**
+  - This core prop getter is required to to enable absolute layout for footers
+
 ### Example (Full Width Resizable Table)
 
 - [Source](https://github.com/tannerlinsley/react-table/tree/master/examples/full-width-resizable-table)

--- a/src/plugin-hooks/useAbsoluteLayout.js
+++ b/src/plugin-hooks/useAbsoluteLayout.js
@@ -7,6 +7,7 @@ export const useAbsoluteLayout = hooks => {
   hooks.getTableBodyProps.push(getRowStyles)
   hooks.getRowProps.push(getRowStyles)
   hooks.getHeaderGroupProps.push(getRowStyles)
+  hooks.getFooterGroupProps.push(getRowStyles)
 
   hooks.getHeaderProps.push((props, { column }) => [
     props,
@@ -26,6 +27,17 @@ export const useAbsoluteLayout = hooks => {
         ...cellStyles,
         left: `${cell.column.totalLeft}px`,
         width: `${cell.column.totalWidth}px`,
+      },
+    },
+  ])
+
+  hooks.getFooterProps.push((props, { column }) => [
+    props,
+    {
+      style: {
+        ...cellStyles,
+        left: `${column.totalLeft}px`,
+        width: `${column.totalWidth}px`,
       },
     },
   ])

--- a/src/plugin-hooks/useBlockLayout.js
+++ b/src/plugin-hooks/useBlockLayout.js
@@ -16,6 +16,7 @@ const getRowStyles = (props, { instance }) => [
 export const useBlockLayout = hooks => {
   hooks.getRowProps.push(getRowStyles)
   hooks.getHeaderGroupProps.push(getRowStyles)
+  hooks.getFooterGroupProps.push(getRowStyles)
 
   hooks.getHeaderProps.push((props, { column }) => [
     props,
@@ -33,6 +34,16 @@ export const useBlockLayout = hooks => {
       style: {
         ...cellStyles,
         width: `${cell.column.totalWidth}px`,
+      },
+    },
+  ])
+
+  hooks.getFooterProps.push((props, { column }) => [
+    props,
+    {
+      style: {
+        ...cellStyles,
+        width: `${column.totalWidth}px`,
       },
     },
   ])

--- a/src/plugin-hooks/useFlexLayout.js
+++ b/src/plugin-hooks/useFlexLayout.js
@@ -2,8 +2,10 @@ export function useFlexLayout(hooks) {
   hooks.getTableProps.push(getTableProps)
   hooks.getRowProps.push(getRowStyles)
   hooks.getHeaderGroupProps.push(getRowStyles)
+  hooks.getFooterGroupProps.push(getRowStyles)
   hooks.getHeaderProps.push(getHeaderProps)
   hooks.getCellProps.push(getCellProps)
+  hooks.getFooterProps.push(getFooterProps)
 }
 
 useFlexLayout.pluginName = 'useFlexLayout'
@@ -50,6 +52,20 @@ const getCellProps = (props, { cell }) => [
       flex: `${cell.column.totalFlexWidth} 0 auto`,
       minWidth: `${cell.column.totalMinWidth}px`,
       width: `${cell.column.totalWidth}px`,
+    },
+  },
+]
+
+const getFooterProps = (props, { column }) => [
+  props,
+  {
+    style: {
+      boxSizing: 'border-box',
+      flex: column.totalFlexWidth
+        ? `${column.totalFlexWidth} 0 auto`
+        : undefined,
+      minWidth: `${column.totalMinWidth}px`,
+      width: `${column.totalWidth}px`,
     },
   },
 ]


### PR DESCRIPTION
This PR adds support for footers to `useBlockLayout`, `useFlexLayout`, and `useAbsoluteLayout`, and updates the docs for these plugins to mention the `getFooterGroupProps` and `getFooterProps` prop getters.