### PR TITLE
Allow user to specify default Header

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -75,7 +75,6 @@ export function decorateColumn(column, userDefaultColumn) {
     Footer: () => <>&nbsp;</>,
     ...defaultColumn,
     ...userDefaultColumn,
-    ...column,
   })
   return column
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,7 +75,13 @@ export function decorateColumn(column, userDefaultColumn) {
     Footer: () => <>&nbsp;</>,
     ...defaultColumn,
     ...userDefaultColumn,
+    ...column,
   })
+
+  // column already has default Header property
+  if (userDefaultColumn.Header) {
+    column.Header = userDefaultColumn.Header;
+  }
   return column
 }
 


### PR DESCRIPTION
[Issue 2457](https://github.com/tannerlinsley/react-table/issues/2457)

The `Header` option in `defaultColumn` is ignored as `column` already has `Header` specified, meaning it will overwrite anything further down the chain

```
  Object.assign(column, {
    // Make sure there is a fallback header, just in case
    Header: () => <>&nbsp;</>,
    Footer: () => <>&nbsp;</>,
    ...defaultColumn,
    ...userDefaultColumn,
    ...column,
  })
```