### PR TITLE
fix(aggregations): update syntax in unique aggregation function

### DIFF
--- a/src/aggregations.js
+++ b/src/aggregations.js
@@ -68,7 +68,7 @@ export function median(values) {
 }
 
 export function unique(values) {
-  return [...new Set(values).values()]
+  return Array.from(new Set(values).values())
 }
 
 export function uniqueCount(values) {


### PR DESCRIPTION
Update syntax in return line of unique aggregation function
Use Array.from() instead of the spread operator [...]
Motivation: prevent polyfilling to [].concat() to enable reference by string in column definitions

closes #2173