### PR TITLE
docs: fix material ui examples links

### DIFF
--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -222,13 +222,13 @@
             },
             {
               "title": "Material-UI",
-              "path": "/docs/examples/material-UI-components",
-              "editUrl": "/docs/examples/material-UI-components.mdx"
+              "path": "/docs/examples/material-ui-components",
+              "editUrl": "/docs/examples/material-ui-components.mdx"
             },
             {
               "title": "Material-UI Kitchen Sink",
-              "path": "/docs/examples/material-UI-kitchen-sink",
-              "editUrl": "/docs/examples/material-UI-kitchen-sink.mdx"
+              "path": "/docs/examples/material-ui-kitchen-sink",
+              "editUrl": "/docs/examples/material-ui-kitchen-sink.mdx"
             },
             {
               "title": "RMWC Table",


### PR DESCRIPTION
The links for `material-ui` and `material-ui-kitchen-sink` in the docs are broken and throw a 404. 

The path has an uppercase `UI` term in the path. This PR changes it to lowercase so the links work as expected