### PR TITLE
Fix dead link in readme

### DIFF
--- a/examples/sorting/README.md
+++ b/examples/sorting/README.md
@@ -65,7 +65,7 @@ By default, the sorting will be `alphanumeric`. This can be changed in your `col
 Other options include `basic` and `datetime`.
 Note that if you're planning on sorting numbers between 0 and 1, `basic` sorting will be more accurate.
 
-More information can be found in the [API Docs](https://github.com/tannerlinsley/react-table/blob/master/docs/src/pages/docs/api/useSortBy.md)
+More information can be found in the [API Docs](https://react-table.tanstack.com/docs/api/useSortBy)
 
 ````diff
 const columns = React.useMemo(

--- a/examples/sorting/README.md
+++ b/examples/sorting/README.md
@@ -65,7 +65,7 @@ By default, the sorting will be `alphanumeric`. This can be changed in your `col
 Other options include `basic` and `datetime`.
 Note that if you're planning on sorting numbers between 0 and 1, `basic` sorting will be more accurate.
 
-More information can be found in the [API Docs](/docs/api/useSortBy.md)
+More information can be found in the [API Docs](https://github.com/tannerlinsley/react-table/blob/master/docs/src/pages/docs/api/useSortBy.md)
 
 ````diff
 const columns = React.useMemo(


### PR DESCRIPTION
The link to the API documentation went to a 404, so I switched it to where the API documentation is currently located.