### PR TITLE
fix: docsearch is rendered twice with keyboard shortcuts

### DIFF
--- a/docs/src/components/LayoutDocs.js
+++ b/docs/src/components/LayoutDocs.js
@@ -60,7 +60,14 @@ export const LayoutDocs = props => {
       )}
       <div>
         {isMobile ? (
-          <Nav />
+          <>
+            <Nav />
+            <Sticky shadow>
+              <SidebarMobile>
+                <SidebarRoutes isMobile={true} routes={routes} />
+              </SidebarMobile>
+            </Sticky>
+          </>
         ) : (
           <Sticky>
             <Nav />
@@ -72,17 +79,14 @@ export const LayoutDocs = props => {
         />
         <div className="block">
           <>
-            <Sticky shadow>
-              <SidebarMobile>
-                <SidebarRoutes isMobile={true} routes={routes} />
-              </SidebarMobile>
-            </Sticky>
 
             <div className="container mx-auto pb-12 pt-6 content">
               <div className="flex relative">
-                <Sidebar fixed>
-                  <SidebarRoutes routes={routes} />
-                </Sidebar>
+                {!isMobile && (
+                  <Sidebar fixed>
+                    <SidebarRoutes routes={routes} />
+                  </Sidebar>
+                )}
 
                 <div className={s['markdown'] + ' w-full docs'}>
                   <h1>{props.meta.title}</h1>


### PR DESCRIPTION
this PR addresses the same issue. 

https://github.com/tannerlinsley/react-query/pull/733#issue-447454853