### PR TITLE
Fix bug in sortData subRows

### DIFF
--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -321,7 +321,7 @@ function useInstance(instance) {
       // If there are sub-rows, sort them
       sortedData.forEach(row => {
         sortedFlatRows.push(row)
-        if (!row.subRows || row.subRows.length <= 1) {
+        if (!row.subRows || row.subRows.length < 1) {
           return
         }
         row.subRows = sortData(row.subRows)


### PR DESCRIPTION
Fix sort subRows stop recursion when subRows length is one.
If row.subRows length is one, the subRows of row.subRows[0] will not sort in recursion