### PR TITLE
chore: Enforce `useColumnOrder` to be used before useGroupBy

### DIFF
--- a/src/plugin-hooks/useGroupBy.js
+++ b/src/plugin-hooks/useGroupBy.js
@@ -136,8 +136,8 @@ function useInstance(instance) {
     getHooks,
   } = instance
 
-  ensurePluginOrder(plugins, ['useFilters'], 'useGroupBy')
-
+  ensurePluginOrder(plugins, ['useColumnOrder', 'useFilters'], 'useGroupBy')
+  
   const getInstance = useGetLatest(instance)
 
   allColumns.forEach(column => {


### PR DESCRIPTION
so that column order change done by grouping is applicable..on top of ordering done by useColumnOrder