### PR TITLE
feat(useSortBy): set sortBy state via method at once

### DIFF
--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -15,6 +15,7 @@ import * as sortTypes from '../sortTypes'
 
 // Actions
 actions.resetSortBy = 'resetSortBy'
+actions.setAllSortBy = 'setAllSortBy'
 actions.toggleSortBy = 'toggleSortBy'
 actions.clearSortBy = 'clearSortBy'
 
@@ -75,6 +76,14 @@ function reducer(state, action, previousState, instance) {
     return {
       ...state,
       sortBy: newSortBy,
+    }
+  }
+
+  if (action.type === actions.setAllSortBy) {
+    const { sortBy } = action
+    return {
+      ...state,
+      sortBy,
     }
   }
 
@@ -198,6 +207,13 @@ function useInstance(instance) {
     plugins,
     ['useFilters', 'useGlobalFilter', 'useGroupBy', 'usePivotColumns'],
     'useSortBy'
+  )
+
+  const setAllSortBy = React.useCallback(
+    sortBy => {
+      dispatch({ type: actions.setAllSortBy, sortBy })
+    },
+    [dispatch]
   )
 
   // Updates sorting based on a columnId, desc flag and multi flag
@@ -356,6 +372,7 @@ function useInstance(instance) {
     sortedFlatRows,
     rows: sortedRows,
     flatRows: sortedFlatRows,
+    setAllSortBy,
     toggleSortBy,
   })
 }

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -15,7 +15,7 @@ import * as sortTypes from '../sortTypes'
 
 // Actions
 actions.resetSortBy = 'resetSortBy'
-actions.setAllSortBy = 'setAllSortBy'
+actions.setSortBy = 'setSortBy'
 actions.toggleSortBy = 'toggleSortBy'
 actions.clearSortBy = 'clearSortBy'
 
@@ -79,7 +79,7 @@ function reducer(state, action, previousState, instance) {
     }
   }
 
-  if (action.type === actions.setAllSortBy) {
+  if (action.type === actions.setSortBy) {
     const { sortBy } = action
     return {
       ...state,
@@ -209,9 +209,9 @@ function useInstance(instance) {
     'useSortBy'
   )
 
-  const setAllSortBy = React.useCallback(
+  const setSortBy = React.useCallback(
     sortBy => {
-      dispatch({ type: actions.setAllSortBy, sortBy })
+      dispatch({ type: actions.setSortBy, sortBy })
     },
     [dispatch]
   )
@@ -372,7 +372,7 @@ function useInstance(instance) {
     sortedFlatRows,
     rows: sortedRows,
     flatRows: sortedFlatRows,
-    setAllSortBy,
+    setSortBy,
     toggleSortBy,
   })
 }


### PR DESCRIPTION
It would be nice and consistent if we have something like `setAllSortBy`, which sets sortBy state at once, similar to `setAllFilters`.