### PR TITLE
Add useExpanded in the pluginOrder 

### DIFF
--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -174,7 +174,7 @@ function useInstance(instance) {
 
   ensurePluginOrder(
     plugins,
-    ['useFilters', 'useGroupBy', 'useSortBy'],
+    ['useFilters', 'useGroupBy', 'useSortBy', 'useExpanded'],
     'useRowSelect'
   )
 


### PR DESCRIPTION
Selection get broken when rows are expanded if the plugin order is wrong.
#2578 