### PR TITLE
fix(useFlexLayout): change table min width to be the sum of min width of all columns

### DIFF
--- a/src/plugin-hooks/useFlexLayout.js
+++ b/src/plugin-hooks/useFlexLayout.js
@@ -14,7 +14,7 @@ const getTableProps = (props, { instance }) => [
   props,
   {
     style: {
-      minWidth: `${instance.totalColumnsWidth}px`,
+      minWidth: `${instance.totalColumnsMinWidth}px`,
     },
   },
 ]


### PR DESCRIPTION
Table minimum width should be the sum of minimum width of all columns so the table can be responsive and shrink to the minimum width possible.