### PR TITLE
docs: fix material-ui codesanbox link

### DIFF
--- a/docs/src/pages/docs/examples/material-ui-components.md
+++ b/docs/src/pages/docs/examples/material-ui-components.md
@@ -4,11 +4,11 @@ title: Material-UI
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/material-ui-components)
-- [View Source](https://github.com/tannerlinsley/react-table/tree/master/examples/material-ui-components)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/material-UI-components)
+- [View Source](https://github.com/tannerlinsley/react-table/tree/master/examples/material-UI-components)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/material-ui-components?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/material-UI-components?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-table: material-ui-components"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{


### PR DESCRIPTION
This Pr is fixing the links to the codesanbox.

<img width="1785" alt="Screen Shot 2020-08-19 at 08 02 33" src="https://user-images.githubusercontent.com/2073951/90627550-7cc76900-e1f2-11ea-8531-6ea77984cd26.png">
