### PR TITLE
fix(useRowSelect): change to toggleRowSelected reducer to use the previous state

### DIFF
--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -142,11 +142,7 @@ function reducer(state, action, previousState, instance) {
     const { id, value: setSelected } = action
     const { rowsById, selectSubRows = true, getSubRows } = instance
 
-    // Join the ids of deep rows
-    // to make a key, then manage all of the keys
-    // in a flat object
-    const row = rowsById[id]
-    const isSelected = row.isSelected
+    const isSelected = id in state.selectedRowIds
     const shouldExist =
       typeof setSelected !== 'undefined' ? setSelected : !isSelected
 


### PR DESCRIPTION
Change to toggleRowSelected reducer action to use the previous state. The reasoning for this change is that due to when row.isSelected was being updated when you would select another row it would deselect the previous row.

(#2171)