### PR TITLE
chore(actions): add cache to NPM dependencies on GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,43 +3,41 @@ name: react-table tests
 on:
   push:
     branches:
-      - 'master'
+      - "master"
+      - "next"
+      - "6.x"
   pull_request:
 
 jobs:
   test:
-    name: 'node ${{ matrix.node }} ${{ matrix.os }} '
-    runs-on: '${{ matrix.os }}'
+    name: "Node ${{ matrix.node }}"
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node: [12, 10]
+        node: [10, 12, 14]
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - run: npm i -g yarn
-      - run: yarn --frozen-lockfile
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
       - run: yarn test:ci
 
   publish-module:
-    name: 'Publish Module to NPM'
+    name: "Publish Module to NPM"
     needs: test
-    if: github.ref == 'refs/heads/master' #publish only when merged in master, not on PR
+    # publish only when merged in master on original repo, not on PR
+    if: github.repository == 'tannerlinsley/react-table' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/6.x')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
-      - run: npm i -g yarn
-      - run: yarn --frozen-lockfile
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
       - run: npx semantic-release@17
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-table",
-  "version": "7.0.5",
+  "version": "1.0.0-semantic-release",
   "description": "Hooks for building lightweight, fast and extendable datagrids for React",
   "license": "MIT",
   "homepage": "https://react-table.tanstack.com",
@@ -28,12 +28,20 @@
     "build": "cross-env NODE_ENV=production rollup -c",
     "start": "rollup -c -w",
     "prepare": "yarn build",
-    "release": "yarn publish",
-    "releaseNext": "yarn publish --tag next",
     "format": "prettier {src,src/**,examples/*/src,examples/*/src/**}/*.{md,js,jsx,tsx} --write",
     "docz:build": "docz build",
     "docz:dev": "docz dev",
     "docz:serve": "docz build && docz serve"
+  },
+  "release": {
+    "branches": [
+      "6.x",
+      "master",
+      {
+        "name": "next",
+        "prerelease": true
+      }
+    ]
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
This uses [bahmutov/npm-install](https://github.com/bahmutov/npm-install) to install NPM dependencies with caching without any configuration.