### PR TITLE
Fix pagination on sort

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -65,8 +65,8 @@ export default class ReactTablePagination extends Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    if (prevProps.page !== this.props.page && prevState.page !== this.state.page) {
-      // this is probably safe because we only update when old/new state.page are different
+    if (prevProps.page !== this.props.page || prevState.page !== this.state.page) {
+      // this is probably safe because we only update when old/new props/state.page are different
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         page: this.props.page,


### PR DESCRIPTION
When navigating to any page that is not the first one, and then sorting - the paginator input is not updated.
This means it will show the previous page number from the state, instead of getting the updated page number (which is 1) from the props.