### PR TITLE
docs: fix broken material ui kitchen sink links

### DIFF
--- a/docs/src/pages/docs/examples/material-ui-kitchen-sink.md
+++ b/docs/src/pages/docs/examples/material-ui-kitchen-sink.md
@@ -4,11 +4,11 @@ title: Material-UI Kitchen Sink
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/material-ui-kitchen-sink)
-- [View Source](https://github.com/tannerlinsley/react-table/tree/master/examples/material-ui-kitchen-sink)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/material-UI-kitchen-sink)
+- [View Source](https://github.com/tannerlinsley/react-table/tree/master/examples/material-UI-kitchen-sink)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/material-ui-kitchen-sink?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/material-UI-kitchen-sink?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-table: material-ui-kitchen-sink"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/examples/material-UI-kitchen-sink/README.md
+++ b/examples/material-UI-kitchen-sink/README.md
@@ -2,7 +2,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/material-ui-kitchen-sink)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/material-UI-kitchen-sink)
 - `yarn` and `yarn start` to run and edit the example
 
 It demonstrates client side pagination, sorting, global search, add row, and delete row.


### PR DESCRIPTION
Fixes #2658 

There were two main issues:

- docs/src/manifests/manifest.json had an entry for `/docs/examples/material-ui-kitchen-sink`, but the file name was `material-ui-enhanced-table`
- `material-ui` was actually `material-UI` in both the repository and in the codesandbox url

Page in production, prior to fix:

![image](https://user-images.githubusercontent.com/1777011/91255318-63a24900-e719-11ea-8f61-583c8d800649.png)

Page running locally, after fix:

![image](https://user-images.githubusercontent.com/1777011/91255335-6e5cde00-e719-11ea-8352-63d7bf90e2fc.png)

I noticed all of the "Edit this page on GitHub" links were broken in the docs, so I left that link alone since it seems like a larger initiative to repair.

![image](https://user-images.githubusercontent.com/1777011/91255503-c562b300-e719-11ea-9efe-678be9f060f3.png)
