### PR TITLE
docs: fix broken bootstrap ui links

### DIFF
--- a/docs/src/pages/docs/examples/bootstrap-ui-components.md
+++ b/docs/src/pages/docs/examples/bootstrap-ui-components.md
@@ -4,11 +4,11 @@ title: Bootstrap UI
 toc: false
 ---
 
-- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/bootstrap-ui-components)
-- [View Source](https://github.com/tannerlinsley/react-table/tree/master/examples/bootstrap-ui-components)
+- [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/bootstrap-UI-components)
+- [View Source](https://github.com/tannerlinsley/react-table/tree/master/examples/bootstrap-UI-components)
 
 <iframe
-  src="https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/bootstrap-ui-components?autoresize=1&fontsize=14&theme=dark"
+  src="https://codesandbox.io/embed/github/tannerlinsley/react-table/tree/master/examples/bootstrap-UI-components?autoresize=1&fontsize=14&theme=dark"
   title="tannerlinsley/react-table: bootstrap-ui-components"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   style={{

--- a/examples/bootstrap-UI-components/README.md
+++ b/examples/bootstrap-UI-components/README.md
@@ -2,5 +2,5 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/bootstrap-ui-components)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/master/examples/bootstrap-UI-components)
 - `yarn` and `yarn start` to run and edit the example


### PR DESCRIPTION
Bootstrap ui links are currently broken, this PR fixes them.