### PR TITLE
feat(useSortBy): Add option to disable sorting of subrows

### DIFF
--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -21,6 +21,8 @@ The following options are supported via the main options object passed to `useTa
   - Enables sorting detection functionality, but does not automatically perform row sorting. Turn this on if you wish to implement your own sorting outside of the table (eg. server-side or manual row grouping/nesting)
 - `disableSortBy: Bool`
   - Disables sorting for every column in the entire table.
+- `disableSubRowSortBy: Bool`
+  - Disables sorting on sub rows. Especially helpful for tables with a high M\*N for rows and subrows.
 - `defaultCanSort: Bool`
   - Optional
   - Defaults to `false`

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -195,6 +195,7 @@ function useInstance(instance) {
     manualSortBy,
     defaultCanSort,
     disableSortBy,
+    disableSubRowSortBy = false,
     flatHeaders,
     state: { sortBy },
     dispatch,
@@ -343,7 +344,9 @@ function useInstance(instance) {
           sortedFlatRows.push(row.subRows[0])
           return
         }
-        row.subRows = sortData(row.subRows)
+        if (!disableSubRowSortBy) {
+          row.subRows = sortData(row.subRows)
+        }
       })
 
       return sortedData
@@ -358,6 +361,7 @@ function useInstance(instance) {
     allColumns,
     orderByFn,
     userSortTypes,
+    disableSubRowSortBy,
   ])
 
   const getAutoResetSortBy = useGetLatest(autoResetSortBy)


### PR DESCRIPTION
Add flag to initial state called disableSubRowSortBy which, if true, will not sort the sub rows in a table. This is to increase performance for long tables where each row has sub rows. Sorting of sub rows is done even if the sub rows are not showing, which can lead to performance issues. The default value of this flag is false, so existing tables will not see any changes in how they work.