### PR TITLE
fix(useGroupBy): crash on selecting row with grouping

### DIFF
--- a/src/plugin-hooks/useGroupBy.js
+++ b/src/plugin-hooks/useGroupBy.js
@@ -395,6 +395,8 @@ function useInstance(instance) {
     }
   }, [dispatch, manualGroupBy ? null : data])
 
+  const bindedRowsById = Object.assign({}, rowsById, groupedRowsById);
+
   Object.assign(instance, {
     preGroupedRows: rows,
     preGroupedFlatRow: flatRows,
@@ -408,7 +410,7 @@ function useInstance(instance) {
     nonGroupedRowsById,
     rows: groupedRows,
     flatRows: groupedFlatRows,
-    rowsById: groupedRowsById,
+    rowsById: bindedRowsById,
     toggleGroupBy,
     setGroupBy,
   })


### PR DESCRIPTION
Fixes
- https://github.com/tannerlinsley/react-table/issues/2465

Reason -

rowsById was getting changed after grouping, but we only need update.