### PR TITLE
fix: do not crash when headerIdWidths is undefined

### DIFF
--- a/src/plugin-hooks/useResizeColumns.js
+++ b/src/plugin-hooks/useResizeColumns.js
@@ -174,7 +174,7 @@ function reducer(state, action) {
 
   if (action.type === actions.columnResizing) {
     const { clientX } = action
-    const { startX, columnWidth, headerIdWidths } = state.columnResizing
+    const { startX, columnWidth, headerIdWidths = [] } = state.columnResizing
 
     const deltaX = clientX - startX
     const percentageDeltaX = deltaX / columnWidth


### PR DESCRIPTION
Since we upgraded React Table we started getting this error when we try to resize a column:

![image](https://user-images.githubusercontent.com/5382443/94448799-a1c4d980-01ab-11eb-8346-66992a803816.png)

This fix should prevent the code from erroring.