### PR TITLE
fix(useGroupBy): Improve performance

### DIFF
--- a/src/plugin-hooks/useGroupBy.js
+++ b/src/plugin-hooks/useGroupBy.js
@@ -238,32 +238,6 @@ function useInstance(instance) {
           return
         }
 
-        // Get the columnValues to aggregate
-        const groupedValues = groupedRows.map(row => row.values[column.id])
-
-        // Get the columnValues to aggregate
-        const leafValues = leafRows.map(row => {
-          let columnValue = row.values[column.id]
-
-          if (!depth && column.aggregateValue) {
-            const aggregateValueFn =
-              typeof column.aggregateValue === 'function'
-                ? column.aggregateValue
-                : userAggregations[column.aggregateValue] ||
-                  aggregations[column.aggregateValue]
-
-            if (!aggregateValueFn) {
-              console.info({ column })
-              throw new Error(
-                `React Table: Invalid column.aggregateValue option for column listed above`
-              )
-            }
-
-            columnValue = aggregateValueFn(columnValue, row, column)
-          }
-          return columnValue
-        })
-
         // Aggregate the values
         let aggregateFn =
           typeof column.aggregate === 'function'
@@ -272,6 +246,32 @@ function useInstance(instance) {
               aggregations[column.aggregate]
 
         if (aggregateFn) {
+          // Get the columnValues to aggregate
+          const groupedValues = groupedRows.map(row => row.values[column.id])
+
+          // Get the columnValues to aggregate
+          const leafValues = leafRows.map(row => {
+            let columnValue = row.values[column.id]
+
+            if (!depth && column.aggregateValue) {
+              const aggregateValueFn =
+                typeof column.aggregateValue === 'function'
+                  ? column.aggregateValue
+                  : userAggregations[column.aggregateValue] ||
+                    aggregations[column.aggregateValue]
+
+              if (!aggregateValueFn) {
+                console.info({ column })
+                throw new Error(
+                  `React Table: Invalid column.aggregateValue option for column listed above`
+                )
+              }
+
+              columnValue = aggregateValueFn(columnValue, row, column)
+            }
+            return columnValue
+          })
+
           values[column.id] = aggregateFn(leafValues, groupedValues)
         } else if (column.aggregate) {
           console.info({ column })


### PR DESCRIPTION
Don't do costly operations (for calculation of groupedValues and leafValues), if the given column is not participating for aggregation, this will improve grouping performance many folds.