### PR TITLE
docs: add link to Releases from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.0.5
 
-- Added semantic release support. So no more changelog entries here! See ya!
+- Added semantic release support. So no more changelog entries here - see [Releases](https://github.com/tannerlinsley/react-table/releases) instead! See ya!
 
 ## 7.0.4
 


### PR DESCRIPTION
Just in case anyone is looking for where changelog entries are now.  Releases is pretty standard place already, but this saves a bit looking.