### PR TITLE
fix: canNavigate check in goToPage reducer

### DIFF
--- a/src/plugin-hooks/usePagination.js
+++ b/src/plugin-hooks/usePagination.js
@@ -52,7 +52,7 @@ function reducer(state, action, previousState, instance) {
       canNavigate =
         pageCount === -1
           ? page.length >= state.pageSize
-          : newPageIndex <= pageCount
+          : newPageIndex < pageCount
     } else if (newPageIndex < state.pageIndex) {
       // prev page
       canNavigate = newPageIndex > -1


### PR DESCRIPTION
Since the pageIndex is zero based it has to be less than pageCount
for canNavigate to be true. If pageIndex is equal to pageCount,
canNavigate should be false, otherwise a non-existing page would be accessed.