### PR TITLE
docs: rework filtering docs for clarity and completeness

### DIFF
--- a/docs/src/pages/docs/api/useFilters.md
+++ b/docs/src/pages/docs/api/useFilters.md
@@ -3,7 +3,7 @@
 - Plugin Hook
 - Optional
 
-`useFilters` is the hook that implements **row filtering** and can even be used in conjunction with `useGlobalFilter`. It's also important to note that this hook can be used either **before or after** `useGlobalFilter`, depending on the performance characteristics you want to code for.
+`useFilters` is the hook that implements **row filtering** - filtering based upon the data in _specific_ columns. It can be used in conjunction with `useGlobalFilter`, which involves filtering rows based upon data in _any_ column in a given row. It is important to note that this hook can be used either **before or after** `useGlobalFilter`, depending on the performance characteristics you want to code for.
 
 ### Table Options
 
@@ -11,10 +11,10 @@ The following options are supported via the main options object passed to `useTa
 
 - `initialState.filters: Array<Object<id: String, value: any>>`
   - Must be **memoized**
-  - An array of objects containing columnId's and their corresponding filter values. This information is stored in state since the table is allowed to manipulate the filter through user interaction.
+  - An array of objects, each having a column `id` and a corresponding filter `value`. This information is stored in state since the table is allowed to manipulate the filter through user interaction.
 - `manualFilters: Bool`
   - Enables filter detection functionality, but does not automatically perform row filtering.
-  - Turn this on if you wish to implement your own row filter outside of the table (eg. server-side or manual row grouping/nesting)
+  - Turn this on if you wish to implement your own row filter outside of the table (e.g. server-side or manual row grouping/nesting)
 - `disableFilters: Bool`
   - Disables filtering for every column in the entire table.
 - `defaultCanFilter: Bool`
@@ -23,8 +23,7 @@ The following options are supported via the main options object passed to `useTa
   - If set to `true`, all columns will be filterable, regardless if they have a valid `accessor`
 - `filterTypes: Object<filterKey: filterType>`
   - Must be **memoized**
-  - Allows overriding or adding additional filter types for columns to use. If a column's filter type isn't found on this object, it will default to using the built-in filter types.
-  - For more information on filter types, see Filtering
+  - Allows overriding or adding additional filter types for columns to use. If a column's `filter` type isn't found on this object, the column will default to using the built-in filter types.
 - `autoResetFilters: Boolean`
   - Defaults to `true`
   - When `true`, the `filters` state will automatically reset if any of the following conditions are met:
@@ -40,42 +39,45 @@ The following options are supported on any `Column` object passed to the `column
   - **Required**
   - Receives the table instance and column model as props
   - Must return valid JSX
-  - This function (or component) is used to render this column's filter UI, eg.
+  - This function (or component) is used to render this column's filter UI
 - `disableFilters: Bool`
   - Optional
-  - If set to `true`, will disable filtering for this column
+  - If set to `true`, filtering for this column will be disabled
 - `defaultCanFilter: Bool`
   - Optional
   - Defaults to `false`
   - If set to `true`, this column will be filterable, regardless if it has a valid `accessor`
-- `filter: String | Function`
+- `filter: String | Function(rows: Array<Row>, columnIds: Array<ColumnId: String>, filterValue) => Rows[]`
   - Optional
   - Defaults to `text`
-  - The resolved function from the this string/function will be used to filter the this column's data.
-    - If a `string` is passed, the function with that name located on either the custom `filterTypes` option or the built-in filtering types object will be used. If
-    - If a `function` is passed, it will be used directly.
-  - For more information on filter types, see Filtering
-  - If a **function** is passed, it must be **memoized**
+  - The resolved function from this option will be used to filter this column's data.
+    - If a `string` is passed, the function with that name will be used from either the custom `filterTypes` table option (if specified) or from the built-in filtering types object.
+    - If a `function` is passed:
+      - It must be **memoized**
+      - It will be called directly with an array of `rows` to filter, an array of `columnIds` (being a single-element array with the column ID being filtered), and `filterValue`, being the current value of the filter being applied
+      - It must return an `Array` of rows, being the remaining rows that have _not_ been filtered out
 
 ### Instance Properties
 
 The following values are provided to the table `instance`:
 
+- `state.filters: Array<Object<id: String, value: any>>`
+  - The current `filters` values located on the state object. This is an array of objects, each having a column `id` and its current corresponding filter `value`. Example: `[{ id: 'name', value: 'Jane'}, { id: 'age', value: 21 }]`
 - `rows: Array<Row>`
   - An array of **filtered** rows.
 - `preFilteredRows: Array<Row>`
   - The array of rows **used right before filtering**.
-  - Among many other use-cases, these rows are directly useful for building option lists in filters, since the resulting filtered `rows` do not contain every possible option.
+  - Among many other use-cases, these rows are directly useful for displaying the total number of available rows and building option lists in filters, since the resulting filtered `rows` do not contain every possible option.
 - `setFilter: Function(columnId, filterValue) => void`
   - An instance-level function used to update the filter value for a specific column.
 - `setAllFilters: Function(filtersObjectArray) => void`
   - An instance-level function used to update the values for **all** filters on the table, all at once.
-  - filtersObjectArray is an array of objects with id and value keys. Example: `[{ id: 'columnAccessor', value: 'valueToFilter' }]`
-  - Note: You must call setAllFilters with an array, even if that array is empty. eg: `setAllFilters([])`.
+  - `filtersObjectArray` is an array of objects with `id` and `value` keys. Example: `[{ id: 'columnAccessor', value: 'valueToFilter' }]`
+  - **Note:** You must call `setAllFilters` with an array, even if that array is empty. Example: `setAllFilters([])`
 
 ### Column Properties
 
-The following properties are available on every `Column` object returned by the table instance.
+The following properties are available on every `Column` object returned by the table instance:
 
 - `canFilter: Bool`
   - Denotes whether a column is filterable or not depending on if it has a valid accessor/data model or is manually disabled via an option.
@@ -84,10 +86,10 @@ The following properties are available on every `Column` object returned by the 
 - `filterValue: any`
   - The current filter value for this column, resolved from the table state's `filters` object
 - `preFilteredRows: Array<row>`
-  - The array of rows that were originally passed to this columns filter **before** they were filtered.
+  - The array of rows that were originally passed to this column's filter **before** filtering took place.
   - This array of rows can be useful if building faceted filter options.
 - `filteredRows: Array<row>`
-  - The resulting array of rows received from this columns filter **after** they were filtered.
+  - The resulting array of rows received from this column's filter **after** filtering took place.
   - This array of rows can be useful if building faceted filter options.
 
 ### Example

--- a/docs/src/pages/docs/api/useGlobalFilter.md
+++ b/docs/src/pages/docs/api/useGlobalFilter.md
@@ -3,7 +3,7 @@
 - Plugin Hook
 - Optional
 
-`useGlobalFilter` is the hook that implements **global row filtering** (filtering on all rows) and can even be used in conjunction with `useFilters`. It's also important to note that this hook can be used either **before or after** `useFilters`, depending on the performance characteristics you want to code for.
+`useGlobalFilter` is the hook that implements **global row filtering** – in other words, filtering based upon data that may be in _any_ column in a given row. This is often useful as a free-text search across all columns simultaneously. It can be used in conjunction with `useFilters`, which involves filtering based upon data in _specific_ columns. It is important to note that this hook can be used either **before or after** `useFilters`, depending on the performance characteristics you want to code for.
 
 ### Table Options
 
@@ -11,24 +11,24 @@ The following options are supported via the main options object passed to `useTa
 
 - `initialState.globalFilter: any`
   - Must be **memoized**
-  - An array of objects containing columnId's and their corresponding filter values. This information is stored in state since the table is allowed to manipulate the filter through user interaction.
-- `globalFilter: String | Function`
+  - The initial value of the global filter. This information is stored in state since the table is allowed to manipulate the filter through user interaction.
+- `globalFilter: String | Function(rows: Array<Row>, columnIds: Array<ColumnId: String>, globalFilterValue) => Rows[]`
   - Optional
   - Defaults to `text`
-  - The resolved function from the this string/function will be used to filter the table's data.
-    - If a `string` is passed, the function with that name located on either the custom `filterTypes` option or the built-in filtering types object will be used. If
-    - If a `function` is passed, it will be used directly.
-  - For more information on filter types, see Filtering
-  - If a **function** is passed, it must be **memoized**
+  - The resolved function from this option will be used to filter the table's data.
+    - If a `string` is passed, the function with that name will be used from either the custom `filterTypes` table option (if specified) or used from the built-in filtering types object.
+    - If a `function` is passed:
+      - It must be **memoized**
+      - It will be called directly with an array of `rows` to filter, an array of `columnIds` (being the column IDs that global filtering is being applied to), and `globalFilterValue`, being the current value of the global filter
+      - It must return an `Array` of rows, being the remaining rows that have _not_ been filtered out according to the `globalFilterValue` specified
 - `manualGlobalFilter: Bool`
   - Enables filter detection functionality, but does not automatically perform row filtering.
-  - Turn this on if you wish to implement your own row filter outside of the table (eg. server-side or manual row grouping/nesting)
+  - Turn this on if you wish to implement your own row filter outside of the table (e.g. server-side or manual row grouping/nesting)
 - `disableGlobalFilter: Bool`
   - Disables global filtering for every column in the entire table.
 - `filterTypes: Object<filterKey: filterType>`
   - Must be **memoized**
-  - Allows overriding or adding additional filter types for the table to use. If the globalFilter type isn't found on this object, it will default to using the built-in filter types.
-  - For more information on filter types, see Filtering
+  - Allows overriding or adding additional filter types for the table to use. If the `globalFilter` type isn't found on this object, the table will default to using the built-in filter types.
 - `autoResetGlobalFilter: Boolean`
   - Defaults to `true`
   - When `true`, the `globalFilter` state will automatically reset if any of the following conditions are met:
@@ -38,21 +38,23 @@ The following options are supported via the main options object passed to `useTa
 
 ### Column Options
 
-The following options are supported on any `Column` object passed to the `columns` option in `useTable()`
+The following options are supported on any `Column` object passed to the `columns` option in `useTable()`:
 
 - `disableGlobalFilter: Bool`
   - Optional
-  - If set to `true`, will disable global filtering for this column
+  - If set to `true`, global filtering will be disabled for this column
 
 ### Instance Properties
 
 The following values are provided to the table `instance`:
 
+- `state.globalFilter: String`
+  - The current `globalFilter` value, located on the state object.
 - `rows: Array<Row>`
   - An array of **filtered** rows.
 - `preGlobalFilteredRows: Array<Row>`
   - The array of rows **used right before filtering**.
-  - Among many other use-cases, these rows are directly useful for building option lists in filters, since the resulting filtered `rows` do not contain every possible option.
+  - Among many other use-cases, these rows are directly useful for displaying the total number of available rows and building option lists in filters, since the resulting filtered `rows` do not contain every possible option.
 - `setGlobalFilter: Function(filterValue) => void`
   - An instance-level function used to update the global filter value.
 


### PR DESCRIPTION
This PR updates documentation for `useFilters` and `useGlobalFilter` to clarify what each does, removes old documentation (from v6, seemingly), improves wording and adds `state` details.

Currently, the documentation is hard to follow on why one would use `useFilters` compared to `useGlobalFilter`.  It was hard to know what each applied to (be it a row, column(s) or the table as a whole) without looking at the examples in action.  Once you see that, it makes sense - the former is filtering rows on a per-column basis and the latter is a single filter value being applied to _all_ columns at once.

These changes augment the existing docs with this info and explain the _other_ filter hook respectively, aiming to clarify what is being filtered and by what type of value.

Other improvements:
* Addition of `state` object inclusions
* Formatting for highlighting object structures and `keys`
* General cleanup
* Spelling and grammar

Feedback very welcome - happy to tweak the text to improve it further.