### PR TITLE
Clarify acceptable return values for `sortType`

### DIFF
--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -74,7 +74,7 @@ The following options are supported on any `Column` object passed to the `column
   - This may be useful in situations where positive and negative connotation is inverted, eg. a Golfing score where a lower score is considered more positive than a higher one.
 - `sortType: String | Function(rowA: <Row>, rowB: <Row>, columnId: String, desc: Bool)`
   - Used to compare 2 rows of data and order them correctly.
-  - If a **function** is passed, it must be **memoized**. The sortType function should return -1 if rowA is larger, and 1 if rowB is larger. `react-table` will take care of the rest.
+  - If a **function** is passed, it must be **memoized**. The sortType function should return a negative value if rowA is larger, and a positive value if rowB is larger. `react-table` will take care of the rest.
   - String options: `basic`, `datetime`, `alphanumeric`. Defaults to `alphanumeric`.
   - The resolved function from the this string/function will be used to sort the this column's data.
     - If a `string` is passed, the function with that name located on either the custom `sortTypes` option or the built-in sorting types object will be used.

--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -74,7 +74,7 @@ The following options are supported on any `Column` object passed to the `column
   - This may be useful in situations where positive and negative connotation is inverted, eg. a Golfing score where a lower score is considered more positive than a higher one.
 - `sortType: String | Function(rowA: <Row>, rowB: <Row>, columnId: String, desc: Bool)`
   - Used to compare 2 rows of data and order them correctly.
-  - If a **function** is passed, it must be **memoized**. The sortType function should return a negative value if rowA is larger, and a positive value if rowB is larger. `react-table` will take care of the rest.
+  - If a **function** is passed, it must be **memoized**. The sortType function should return a negative value if rowA is larger, a positive value if rowB is larger, or zero if the rows are equal. `react-table` will take care of the rest.
   - String options: `basic`, `datetime`, `alphanumeric`. Defaults to `alphanumeric`.
   - The resolved function from the this string/function will be used to sort the this column's data.
     - If a `string` is passed, the function with that name located on either the custom `sortTypes` option or the built-in sorting types object will be used.


### PR DESCRIPTION
Since the [implementation](https://github.com/jclem/react-table/blob/v7.6.1/src/plugin-hooks/useSortBy.js#L387) just uses `Array.prototype.sort`, I wonder if we can change the documented return type for the `sortType` function to reflect that. Likewise, `0` is presumably also an acceptable return value, and we should document that, as well.

The reason for what may seem like a rather pedantic change here is to avoid unnecessarily having to convert comparison return values from functions like [`localeCompare`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) (which only specifies generally a negative, positive, or zero value) to `-1` or `1` in order to align with expectations set by react-table documentation.