### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/src/pages/docs/api/useAbsoluteLayout.md
+++ b/docs/src/pages/docs/api/useAbsoluteLayout.md
@@ -5,7 +5,7 @@
 
 `useAbsoluteLayout` is a plugin hook that adds support for headers and cells to be rendered as absolutely positioned `div`s (or other non-table elements) with explicit `width`. Similar to the `useBlockLayout` hook, this becomes useful if and when you need to virtualize rows and cells for performance.
 
-**NOTE:** Although no additional options are needed for this plugin to work, the core column options `width`, `minWidth` and `maxWidth` are used to calculate column and cell widths and must be set. [See Column Options](./useTable.md#column-options) for more information on these options.
+**NOTE:** Although no additional options are needed for this plugin to work, the core column options `width`, `minWidth` and `maxWidth` are used to calculate column and cell widths and must be set. [See Column Options](./useTable#column-options) for more information on these options.
 
 ### Instance Properties
 

--- a/docs/src/pages/docs/api/useBlockLayout.md
+++ b/docs/src/pages/docs/api/useBlockLayout.md
@@ -5,7 +5,7 @@
 
 `useBlockLayout` is a plugin hook that adds support for headers and cells to be rendered as `inline-block` `div`s (or other non-table elements) with explicit `width`. Similar to the `useAbsoluteLayout` hook, this becomes useful if and when you need to virtualize rows and cells for performance.
 
-**NOTE:** Although no additional options are needed for this plugin to work, the core column options `width`, `minWidth` and `maxWidth` are used to calculate column and cell widths and must be set. See `Column Options` ([website](./useTable#column-options)) or ([GitHub](./useTable.md#column-options)) for more information on these options.
+**NOTE:** Although no additional options are needed for this plugin to work, the core column options `width`, `minWidth` and `maxWidth` are used to calculate column and cell widths and must be set. See `Column Options` ([website](./useTable#column-options)) or ([GitHub](./useTable#column-options)) for more information on these options.
 
 ### Row Properties
 

--- a/docs/src/pages/docs/api/useExpanded.md
+++ b/docs/src/pages/docs/api/useExpanded.md
@@ -18,7 +18,7 @@ The following options are supported via the main options object passed to `useTa
   - This information is stored in state since the table is allowed to manipulate the filter through user interaction.
 - `getSubRows: Function(row, relativeIndex) => Rows[]`
   - Optional
-  - See the [useTable hook](./useTable.md#table-options) for more details
+  - See the [useTable hook](./useTable#table-options) for more details
 - `manualExpandedKey: String`
   - Optional
   - Defaults to `expanded`
@@ -33,7 +33,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `expanded` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq.md#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Instance Properties
 

--- a/docs/src/pages/docs/api/useFilters.md
+++ b/docs/src/pages/docs/api/useFilters.md
@@ -29,7 +29,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `filters` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq.md#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Column Options
 

--- a/docs/src/pages/docs/api/usePagination.md
+++ b/docs/src/pages/docs/api/usePagination.md
@@ -35,7 +35,7 @@ The following options are supported via the main options object passed to `useTa
     - `manualFilters` is `false` and `state.filters` is changed
     - `manualGroupBy` is `false` and `state.groupBy` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq.md#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 - `paginateExpandedRows: Bool`
   - Optional
   - Only applies when using the `useExpanded` plugin hook simultaneously

--- a/docs/src/pages/docs/api/useResizeColumns.md
+++ b/docs/src/pages/docs/api/useResizeColumns.md
@@ -13,7 +13,7 @@
 
 ### Column Options
 
-The core column options `width`, `minWidth` and `maxWidth` are used to calculate column and cell widths and must be set. [See Column Options](./useTable.md#column-options) for more information on these options.
+The core column options `width`, `minWidth` and `maxWidth` are used to calculate column and cell widths and must be set. [See Column Options](./useTable#column-options) for more information on these options.
 
 - `disableResizing: Bool`
   - Defaults to `false`

--- a/docs/src/pages/docs/api/useRowSelect.md
+++ b/docs/src/pages/docs/api/useRowSelect.md
@@ -22,7 +22,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `selectedRowIds` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq.md#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Instance Properties
 

--- a/docs/src/pages/docs/api/useRowState.md
+++ b/docs/src/pages/docs/api/useRowState.md
@@ -30,7 +30,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `rowState` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq.md#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Instance Properties
 

--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -49,7 +49,7 @@ The following options are supported via the main options object passed to `useTa
   - When `true`, the `sortBy` state will automatically reset if any of the following conditions are met:
     - `data` is changed
   - To disable, set to `false`
-  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq.md#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
+  - For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](../faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)
 
 ### Column Options
 

--- a/docs/src/pages/docs/api/useTable.md
+++ b/docs/src/pages/docs/api/useTable.md
@@ -41,7 +41,7 @@ The following options are supported via the main options object passed to `useTa
   - If you need to control part of the table state, this is the place to do it.
   - This function is run on every single render, just like a hook and allows you to alter the final state of the table if necessary.
   - You can use hooks inside of this function, but most of the time, we just suggest using `React.useMemo` to memoize your state overrides.
-  - See the FAQ ["How can I manually control the table state?"](../faq.md#how-can-i-manually-control-the-table-state) for a an example.
+  - See the FAQ ["How can I manually control the table state?"](../faq#how-can-i-manually-control-the-table-state) for a an example.
 - `defaultColumn: Object`
   - Optional
   - Defaults to `{}`


### PR DESCRIPTION
I noticed there were some broken links in the documentation due to an extra `.md`, when removing it the links work as expected.