### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/pages/docs/api/useTable.md
+++ b/docs/src/pages/docs/api/useTable.md
@@ -217,7 +217,7 @@ The following properties are available on every `Column` object returned by the 
   - This is the total width in pixels of all columns to the left of this column
   - Specifically useful when using plugin hooks that allow the user to resize column widths
 - `totalWidth: Int`
-  - This is the total width in pixels for this column (if it is a leaf-column) or or all of it's sub-columns (if it is a column group)
+  - This is the total width in pixels for this column (if it is a leaf-column) or or all of its sub-columns (if it is a column group)
   - Specifically useful when using plugin hooks that allow the user to resize column widths
 - `getHeaderProps: Function(?props)`
   - **Required**

--- a/docs/src/pages/docs/faq.md
+++ b/docs/src/pages/docs/faq.md
@@ -53,7 +53,7 @@ Using this approach, you can respond and trigger any type of side-effect using t
 
 ## How can I debounce rapid table state changes?
 
-React Table has a few built-in side-effects of it's own (most of which are meant for resetting parts of the state when `data` changes). By default, these state side-effects are on and when their conditions are met, they immediately fire off actions that will manipulate the table state. Sometimes, this may result in multiple rapid rerenders (usually just 2, or one more than normal), and could cause any side-effects you have watching the table state to also fire multiple times in-a-row. To alleviate this edge-case, React Table exports a `useAsyncDebounce` function that will allow you to debounce rapid side-effects and only use the latest one.
+React Table has a few built-in side-effects of its own (most of which are meant for resetting parts of the state when `data` changes). By default, these state side-effects are on and when their conditions are met, they immediately fire off actions that will manipulate the table state. Sometimes, this may result in multiple rapid rerenders (usually just 2, or one more than normal), and could cause any side-effects you have watching the table state to also fire multiple times in-a-row. To alleviate this edge-case, React Table exports a `useAsyncDebounce` function that will allow you to debounce rapid side-effects and only use the latest one.
 
 A good example of this when doing server-side pagination and sorting, a user changes the `sortBy` for a table and the `pageIndex` is automatically reset to `0` via an internal side effect. This would normally cause our effect below to fire 2 times, but with `useAsyncDebounce` we can make sure our data fetch function only gets called once:
 

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -114,7 +114,7 @@ const Home = () => {
                     </h3>
                     <p className="mt-2  lg:mt-4 text-base xl:text-lg lg:leading-normal leading-6 text-gray-600">
                       Plugins are important for a healthy ecosystem, which is
-                      why React Table has it's very own plugin system allowing
+                      why React Table has its very own plugin system allowing
                       you to override or extend any logical step, stage or
                       process happening under the hood. Are you itching to build
                       your own row grouping and aggregation strategy? It's all


### PR DESCRIPTION
Change `it's` to `its` (3 occurrences).