### PR TITLE
fix(useControlledState): memorize return value of useControlledState

### DIFF
--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -129,7 +129,7 @@ export const useTable = (props, ...plugins) => {
   )
 
   // Start the reducer
-  const [reducerState, dispatch] = React.useReducer(reducer, undefined, () =>
+  const [reducerState, dispatch] = React.useReducer(reducer, getInstance().state, () =>
     reducer(initialState, { type: actions.init })
   )
 

--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -129,7 +129,7 @@ export const useTable = (props, ...plugins) => {
   )
 
   // Start the reducer
-  const [reducerState, dispatch] = React.useReducer(reducer, getInstance().state, () =>
+  const [reducerState, dispatch] = React.useReducer((_, action) => reducer(getInstance().state, action), undefined, () =>
     reducer(initialState, { type: actions.init })
   )
 


### PR DESCRIPTION
The `reducerState` processed by useControlledState should be memorized, ant now it has its own state. I think it might be a bug.